### PR TITLE
Change ffmpeg argument order so that it correctly cuts at keyframes

### DIFF
--- a/src/ffmpeg.js
+++ b/src/ffmpeg.js
@@ -44,8 +44,9 @@ function cut(filePath, format, cutFrom, cutTo) {
     console.log('Cutting from', cutFrom, 'to', cutTo);
 
     const ffmpegArgs = [
+      '-ss', cutFrom,
       '-i', filePath, '-y', '-vcodec', 'copy', '-acodec', 'copy',
-      '-ss', cutFrom, '-t', cutTo - cutFrom,
+      '-to', cutTo,
       '-f', format,
       outFile,
     ];


### PR DESCRIPTION
When I run ffmpeg with the arguments in this order `-i ... -ss ... -t ...`, it produces a video file that has no video for a few initial seconds.  (as far as I can understand this is because it doesn't seek to a keyframe?)

If I change the order to `-ss ... -i ... -t ...`, then the resulting cut videos play properly.

<details>
  <summary>My `ffmpeg -version`</summary><p>

```
ffmpeg version 3.2 Copyright (c) 2000-2016 the FFmpeg developers
built with Apple LLVM version 8.0.0 (clang-800.0.38)
configuration: --prefix=/usr/local/Cellar/ffmpeg/3.2 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-frei0r --enable-libass --enable-libfdk-aac --enable-libfreetype --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopus --enable-librtmp --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libxvid --enable-opencl --disable-lzma --enable-libopenjpeg --disable-decoder=jpeg2000 --extra-cflags=-I/usr/local/Cellar/openjpeg/2.1.2/include/openjpeg-2.1 --enable-nonfree --enable-vda
libavutil      55. 34.100 / 55. 34.100
libavcodec     57. 64.100 / 57. 64.100
libavformat    57. 56.100 / 57. 56.100
libavdevice    57.  1.100 / 57.  1.100
libavfilter     6. 65.100 /  6. 65.100
libavresample   3.  1.  0 /  3.  1.  0
libswscale      4.  2.100 /  4.  2.100
libswresample   2.  3.100 /  2.  3.100
libpostproc    54.  1.100 / 54.  1.100
```
</p>
</details>