### PR TITLE
Offset modified date to respect the frame offset

### DIFF
--- a/src/capture-frame.js
+++ b/src/capture-frame.js
@@ -27,7 +27,8 @@ async function captureFrame(customOutDir, filePath, video, currentTime, captureF
 
   const outPath = util.getOutPath(customOutDir, filePath, `${time}.${ext}`);
   await fs.writeFileAsync(outPath, buf);
-  return util.transferTimestamps(filePath, outPath);
+  const offset = -video.duration + currentTime;
+  return util.transferTimestampsWithOffset(filePath, outPath, offset);
 }
 
 module.exports = captureFrame;

--- a/src/util.js
+++ b/src/util.js
@@ -33,8 +33,19 @@ async function transferTimestamps(inPath, outPath) {
   }
 }
 
+async function transferTimestampsWithOffset(inPath, outPath, offset) {
+  try {
+    const stat = await fs.statAsync(inPath);
+    const time = (stat.mtime.getTime() / 1000) + offset;
+    await fs.utimesAsync(outPath, time, time);
+  } catch (err) {
+    console.error('Failed to set output file modified time', err);
+  }
+}
+
 module.exports = {
   formatDuration,
   getOutPath,
   transferTimestamps,
+  transferTimestampsWithOffset,
 };


### PR DESCRIPTION
Comes in handy when sorting images by modified date when the naming prefix of the originating video file does not follow modified date