### PR TITLE
Add -map 0 parameter in ffmpeg concat command

### DIFF
--- a/src/ffmpeg.js
+++ b/src/ffmpeg.js
@@ -223,6 +223,7 @@ async function mergeFiles(paths, outPath) {
   const ffmpegArgs = [
     '-f', 'concat', '-safe', '0', '-protocol_whitelist', 'file,pipe', '-i', '-',
     '-c', 'copy',
+    '-map', '0',
     '-map_metadata', '0',
     '-y', outPath,
   ];


### PR DESCRIPTION
By adding -map 0 in ffmpeg concat command we'll retain eg. subtitles in the merged / final output file.