### PR TITLE
Add desktop and appdata files for downstreams

### DIFF
--- a/no.mifi.losslesscut.appdata.xml
+++ b/no.mifi.losslesscut.appdata.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>no.mifi.losslesscut</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>LosslessCut</name>
+  <summary>Save space by quickly and losslessly trimming video and audio files</summary>
+  <description>
+    <p>Simple and ultra fast cross platform tool for lossless trimming/cutting of video and audio files. Great for saving space by rough cutting your large video files taken from a video camera, GoPro, drone, etc. It lets you quickly extract the good parts from your videos and discard many gigabytes of data without doing a slow re-encode and thereby losing quality. It extremely fast because it does an almost direct data copy. It is fueled by the awesome ffmpeg (included) for doing the grunt work. It also features some other lossless operations on videos.</p>
+  </description>
+  <launchable type="desktop-id">com.github.mifi.loslesscut.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/mifi/lossless-cut/master/screenshot.jpg</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/mifi/lossless-cut/</url>
+  <url type="bugtracker">https://github.com/mifi/lossless-cut/issues</url>
+  <url type="donation">https://paypal.me/mifino</url>
+  <releases>
+    <release version="2.6.2" date="2019-11-05" />
+  </releases>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/no.mifi.losslesscut.desktop
+++ b/no.mifi.losslesscut.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=LosslessCut
+Comment=simple video editor to trim or cut videos
+Exec=/app/bin/run.sh
+MimeType=video/mpeg;video/x-mpeg;video/msvideo;video/quicktime;video/x-anim;video/x-avi;video/x-ms-asf;video/x-ms-wmv;video/x-msvideo;video/x-nsv;video/x-flc;video/x-fli;video/x-flv;video/vnd.rn-realvideo;video/mp4;video/mp4v-es;video/mp2t;application/ogg;application/x-ogg;video/x-ogm+ogg;audio/x-vorbis+ogg;application/x-matroska;audio/x-matroska;video/x-matroska;video/webm;
+Icon=no.mifi.losslesscut
+Terminal=false
+Type=Application
+Encoding=UTF-8
+Categories=AudioVideo;AudioVideoEditing;
+Keywords=trim;codec;cut;movie;mpeg;avi;h264;mkv;mp4;
+StartupWMClass=losslesscut


### PR DESCRIPTION
This intends to make the lives of downstreams a bit easier. That is, not every downstream needs to create and maintain those files.
I would hope that electron-builder can generate those, but I have absolutely no idea how to make it behave accordingly.

I intend to make a [flatpak](https://github.com/muelli/flathub/tree/cutloss) and publish it on flathub. Having the desktop and the appdata files upstream helps. Also, would you be interested in co-maintaining the app on flathub?