### PR TITLE
CI: Use checkout@v2 and setup-node@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
 


### PR DESCRIPTION
- actions/checkout v2 is faster by doing a shallow clone
- actions/setup-node v2 improves reliability