### PR TITLE
Cleanup option in app state, bug fix.

### DIFF
--- a/public/configStore.js
+++ b/public/configStore.js
@@ -3,6 +3,7 @@ const Store = require('electron-store');
 const defaults = {
   defaults: {
     captureFormat: 'jpeg',
+    cleanupOption: 'all',
     customOutDir: undefined,
     keyframeCut: true,
     autoMerge: false,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,7 +143,7 @@ const App = memo(() => {
   const isCustomFormatSelected = fileFormat !== detectedFileFormat;
 
   const {
-    captureFormat, setCaptureFormat, customOutDir, setCustomOutDir, keyframeCut, setKeyframeCut, preserveMovData, setPreserveMovData, movFastStart, setMovFastStart, avoidNegativeTs, setAvoidNegativeTs, autoMerge, setAutoMerge, timecodeShowFrames, setTimecodeShowFrames, invertCutSegments, setInvertCutSegments, autoExportExtraStreams, setAutoExportExtraStreams, askBeforeClose, setAskBeforeClose, enableAskForImportChapters, setEnableAskForImportChapters, enableAskForFileOpenAction, setEnableAskForFileOpenAction, muted, setMuted, autoSaveProjectFile, setAutoSaveProjectFile, wheelSensitivity, setWheelSensitivity, invertTimelineScroll, setInvertTimelineScroll, language, setLanguage, ffmpegExperimental, setFfmpegExperimental, hideNotifications, setHideNotifications, autoLoadTimecode, setAutoLoadTimecode, autoDeleteMergedSegments, setAutoDeleteMergedSegments, exportConfirmEnabled, setExportConfirmEnabled, segmentsToChapters, setSegmentsToChapters, preserveMetadataOnMerge, setPreserveMetadataOnMerge, simpleMode, setSimpleMode, outSegTemplate, setOutSegTemplate, keyboardSeekAccFactor, setKeyboardSeekAccFactor, keyboardNormalSeekSpeed, setKeyboardNormalSeekSpeed,
+    captureFormat, setCaptureFormat, cleanupOption, setCleanupOption, customOutDir, setCustomOutDir, keyframeCut, setKeyframeCut, preserveMovData, setPreserveMovData, movFastStart, setMovFastStart, avoidNegativeTs, setAvoidNegativeTs, autoMerge, setAutoMerge, timecodeShowFrames, setTimecodeShowFrames, invertCutSegments, setInvertCutSegments, autoExportExtraStreams, setAutoExportExtraStreams, askBeforeClose, setAskBeforeClose, enableAskForImportChapters, setEnableAskForImportChapters, enableAskForFileOpenAction, setEnableAskForFileOpenAction, muted, setMuted, autoSaveProjectFile, setAutoSaveProjectFile, wheelSensitivity, setWheelSensitivity, invertTimelineScroll, setInvertTimelineScroll, language, setLanguage, ffmpegExperimental, setFfmpegExperimental, hideNotifications, setHideNotifications, autoLoadTimecode, setAutoLoadTimecode, autoDeleteMergedSegments, setAutoDeleteMergedSegments, exportConfirmEnabled, setExportConfirmEnabled, segmentsToChapters, setSegmentsToChapters, preserveMetadataOnMerge, setPreserveMetadataOnMerge, simpleMode, setSimpleMode, outSegTemplate, setOutSegTemplate, keyboardSeekAccFactor, setKeyboardSeekAccFactor, keyboardNormalSeekSpeed, setKeyboardNormalSeekSpeed,
   } = useUserPreferences();
 
   const outSegTemplateOrDefault = outSegTemplate || defaultOutSegTemplate;
@@ -596,6 +596,12 @@ const App = memo(() => {
   }, [assureOutDirAccess, ffmpegExperimental, preserveMovData, movFastStart, preserveMetadataOnMerge, customOutDir]);
 
   const toggleCaptureFormat = useCallback(() => setCaptureFormat(f => (f === 'png' ? 'jpeg' : 'png')), [setCaptureFormat]);
+  
+  const toggleCleanupOption = useCallback((cleanupOptionChosen) => 
+    setCleanupOption(f => 
+      (cleanupOptionChosen ? cleanupOptionChosen : f
+    )), [setCleanupOption]);
+
 
   const toggleKeyframeCut = useCallback((showMessage) => setKeyframeCut((val) => {
     const newVal = !val;
@@ -868,11 +874,14 @@ const App = memo(() => {
     // Because we will reset state before deleting files
     const saved = { html5FriendlyPath, dummyVideoPath, filePath, edlFilePath };
 
-    if (!closeFile()) return;
-
-    const trashResponse = await cleanupFilesDialog();
-    console.log('trashResponse', trashResponse);
+    const trashResponse = await cleanupFilesDialog(cleanupOption);
     if (!trashResponse) return;
+
+    if(trashResponse !== cleanupOption){
+      toggleCleanupOption(trashResponse);
+    }
+
+    if (!closeFile()) return;
 
     const deleteTmpFiles = ['all', 'projectAndTmpFiles', 'tmpFiles'].includes(trashResponse);
     const deleteProjectFile = ['all', 'projectAndTmpFiles'].includes(trashResponse);
@@ -913,7 +922,7 @@ const App = memo(() => {
     } finally {
       setWorking();
     }
-  }, [filePath, html5FriendlyPath, dummyVideoPath, closeFile, edlFilePath]);
+  }, [filePath, html5FriendlyPath, dummyVideoPath, closeFile, edlFilePath, cleanupOption, toggleCleanupOption]);
 
   const outSegments = useMemo(() => (invertCutSegments ? inverseCutSegments : apparentCutSegments),
     [invertCutSegments, inverseCutSegments, apparentCutSegments]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -596,8 +596,7 @@ const App = memo(() => {
   }, [assureOutDirAccess, ffmpegExperimental, preserveMovData, movFastStart, preserveMetadataOnMerge, customOutDir]);
 
   const toggleCaptureFormat = useCallback(() => setCaptureFormat(f => (f === 'png' ? 'jpeg' : 'png')), [setCaptureFormat]);
-  
-  const toggleCleanupOption = useCallback((cleanupOptionChosen) => setCleanupOption(f => (cleanupOptionChosen ? cleanupOptionChosen : f)), [setCleanupOption]);
+  const toggleCleanupOption = useCallback((cleanupOptionChosen) => setCleanupOption(f => cleanupOptionChosen || f), [setCleanupOption]);
 
   const toggleKeyframeCut = useCallback((showMessage) => setKeyframeCut((val) => {
     const newVal = !val;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -597,11 +597,7 @@ const App = memo(() => {
 
   const toggleCaptureFormat = useCallback(() => setCaptureFormat(f => (f === 'png' ? 'jpeg' : 'png')), [setCaptureFormat]);
   
-  const toggleCleanupOption = useCallback((cleanupOptionChosen) => 
-    setCleanupOption(f => 
-      (cleanupOptionChosen ? cleanupOptionChosen : f
-    )), [setCleanupOption]);
-
+  const toggleCleanupOption = useCallback((cleanupOptionChosen) => setCleanupOption(f => (cleanupOptionChosen ? cleanupOptionChosen : f)), [setCleanupOption]);
 
   const toggleKeyframeCut = useCallback((showMessage) => setKeyframeCut((val) => {
     const newVal = !val;
@@ -877,7 +873,7 @@ const App = memo(() => {
     const trashResponse = await cleanupFilesDialog(cleanupOption);
     if (!trashResponse) return;
 
-    if(trashResponse !== cleanupOption){
+    if (trashResponse !== cleanupOption) {
       toggleCleanupOption(trashResponse);
     }
 

--- a/src/dialogs.jsx
+++ b/src/dialogs.jsx
@@ -209,12 +209,12 @@ export async function confirmExtractAllStreamsDialog() {
   return !!value;
 }
 
-export async function cleanupFilesDialog() {
+export async function cleanupFilesDialog(cleanupOption) {
   const { value } = await Swal.fire({
     icon: 'warning',
     title: i18n.t('Cleanup files?'),
     input: 'radio',
-    inputValue: 'tmpFiles',
+    inputValue: cleanupOption,
     text: i18n.t('Do you want to move the original file and/or any generated files to trash?'),
     confirmButtonText: i18n.t('Trash'),
     confirmButtonColor: '#d33',
@@ -222,9 +222,9 @@ export async function cleanupFilesDialog() {
     cancelButtonText: i18n.t('Cancel'),
     customClass: { input: 'swal2-losslesscut-radio' },
     inputOptions: {
+      all: i18n.t('Trash original source file, project CSV and auto-generated files'),
       tmpFiles: i18n.t('Trash auto-generated files'),
       projectAndTmpFiles: i18n.t('Trash project CSV and auto-generated files'),
-      all: i18n.t('Trash original source file, project CSV and auto-generated files'),
     },
   });
 

--- a/src/hooks/useUserPreferences.js
+++ b/src/hooks/useUserPreferences.js
@@ -25,6 +25,7 @@ export default () => {
   }
 
   const [captureFormat, setCaptureFormat] = useState(configStore.get('captureFormat'));
+  const [cleanupOption, setCleanupOption] = useState(configStore.get('cleanupOption'));
   useEffect(() => safeSetConfig('captureFormat', captureFormat), [captureFormat]);
   const [customOutDir, setCustomOutDir] = useState(configStore.get('customOutDir'));
   useEffect(() => safeSetConfig('customOutDir', customOutDir), [customOutDir]);
@@ -92,6 +93,8 @@ export default () => {
   return {
     captureFormat,
     setCaptureFormat,
+    cleanupOption,
+    setCleanupOption,
     customOutDir,
     setCustomOutDir,
     keyframeCut,


### PR DESCRIPTION
Hi,
I noticed in latest release the cleanup dialog was closing the video preview even if action was canceled. (Fixed)
I also added a state variable cleanupOption to keep last user's picked option in cleanup dialog.
Finally I put default cleanup option to 'all' since is the one I use the most.
Maybe this changes can be merged... or do you have some observations?
