### PR TITLE
Allow a speed multiplier for L and J keys

### DIFF
--- a/public/configStore.js
+++ b/public/configStore.js
@@ -38,6 +38,7 @@ const defaults = {
   keyboardNormalSeekSpeed: 1,
   enableTransferTimestamps: true,
   outFormatLocked: undefined,
+  speedMultiplier: '2x',
 };
 
 // For portable app: https://github.com/mifi/lossless-cut/issues/645

--- a/src/HelpSheet.jsx
+++ b/src/HelpSheet.jsx
@@ -44,6 +44,8 @@ const HelpSheet = memo(({ visible, onTogglePress, ffmpegCommandLog, currentCutSe
         <div><kbd>SPACE</kbd>, <kbd>k</kbd> {t('Play/pause')}</div>
         <div><kbd>J</kbd> {t('Slow down playback')}</div>
         <div><kbd>L</kbd> {t('Speed up playback')}</div>
+        <div><kbd>SHIFT</kbd> + <kbd>J</kbd> {t('Slow down playback by a multiplier')}</div>
+        <div><kbd>SHIFT</kbd> + <kbd>L</kbd> {t('Speed up playback by a multiplier')}</div>
 
         <h2>{t('Seeking')}</h2>
 

--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -10,7 +10,7 @@ const Settings = memo(({
   invertTimelineScroll, setInvertTimelineScroll, ffmpegExperimental, setFfmpegExperimental,
   enableAskForImportChapters, setEnableAskForImportChapters, enableAskForFileOpenAction, setEnableAskForFileOpenAction,
   hideNotifications, setHideNotifications, autoLoadTimecode, setAutoLoadTimecode,
-  enableTransferTimestamps, setEnableTransferTimestamps,
+  enableTransferTimestamps, setEnableTransferTimestamps, speedMultiplier, setSpeedMultiplier,
 }) => {
   const { t } = useTranslation();
 
@@ -182,6 +182,21 @@ const Settings = memo(({
         <KeyCell>{t('Timeline keyboard seek acceleration')}</KeyCell>
         <Table.TextCell>
           <Button onClick={() => onTunerRequested('keyboardSeekAccFactor')}>{t('Change value')}</Button>
+        </Table.TextCell>
+      </Row>
+
+      <Row>
+        <KeyCell>
+          {t('Playback speed multiplier')}<br />
+          {t('The rate at which playback speed increases or decreases with these key combinations:')}
+          <kbd>SHIFT</kbd> + <kbd>L</kbd>, <kbd>SHIFT</kbd> + <kbd>J</kbd>
+        </KeyCell>
+        <Table.TextCell>
+          <SegmentedControl
+            options={[{ label: '2x / 0.5x', value: '2x' }, { label: '1.1x / 0.9091x', value: '1.1x' }]}
+            value={speedMultiplier}
+            onChange={value => setSpeedMultiplier(value)}
+          />
         </Table.TextCell>
       </Row>
 

--- a/src/hooks/useUserPreferences.js
+++ b/src/hooks/useUserPreferences.js
@@ -86,6 +86,8 @@ export default () => {
   useEffect(() => safeSetConfig('enableTransferTimestamps', enableTransferTimestamps), [enableTransferTimestamps]);
   const [outFormatLocked, setOutFormatLocked] = useState(configStore.get('outFormatLocked'));
   useEffect(() => safeSetConfig('outFormatLocked', outFormatLocked), [outFormatLocked]);
+  const [speedMultiplier, setSpeedMultiplier] = useState(configStore.get('speedMultiplier'));
+  useEffect(() => safeSetConfig('speedMultiplier', speedMultiplier), [speedMultiplier]);
 
 
   // NOTE! This useEffect must be placed after all usages of firstUpdateRef.current (safeSetConfig)
@@ -159,5 +161,7 @@ export default () => {
     setEnableTransferTimestamps,
     outFormatLocked,
     setOutFormatLocked,
+    speedMultiplier,
+    setSpeedMultiplier,
   };
 };


### PR DESCRIPTION
This PR addresses an issue identified in #81 and alluded to in #254: speeding up playback via the keyboard at an exponential rate. It does this by adding a <kbd>SHIFT</kbd> modifier key to the existing <kbd>J</kbd> and <kbd>L</kbd> commands. When in use (by default) a series of <kbd>L</kbd> presses will go from _stopped_ &rarr; _playing_ at 100%, 200%, 400%, 800%, and stop at 1600%. <kbd>J</kbd> will go from _stopped_ &rarr; _playing_ at 100%, 50%, 25%, 13%, and stop at 10%.

* Adds a <kbd>SHIFT</kbd> modifier to <kbd>L</kbd> and <kbd>J</kbd>
* Adds a setting that allows the user to pick the multiplier rate. The two options are 2x/0.5x and 1.1x/0.9091x. These reflect two sets of rates available in the key binding defaults of [IINA](https://iina.io/) which attributes the values to [mpv](https://mpv.io/) and [Movist](https://movistprime.com/). (There's a third set attributed to VLC which is 1.5x/0.6667x; if LC's settings UI had a convention for selecting a third option, this could be added.)
* If speeding up or slowing down (whether using the modifier or not) brings the user from slo-mo to sped-up (or vice-versa), it makes sure to stop at 1x/100% along the way. (This allows the user to use a combination of multiplied speeds and the existing 15% boost without getting stuck unable to return to real-time.)
* Adds documentation for the new commands to the HelpSheet

