### PR TITLE
Spilt up Chinese (Traditional) and Chinese (Simplified) language

### DIFF
--- a/src/Settings.jsx
+++ b/src/Settings.jsx
@@ -40,6 +40,8 @@ const Settings = memo(({
     // sr: 'Cрпски',
     tr: 'Türkçe',
     zh: '中文',
+    'zh_Hant': '繁體中文',
+    'zh_Hans': '简体中文',
     ko: '한국어',
   };
 


### PR DESCRIPTION
I notice that it can't be choose Chinese (Traditional) even if file exists at `locales/zh_Hant/translation.json`.
patched it and split up **Chinese (Traditional)** and **Chinese (Simplified)** language.
Please kindly review, thanks.