### PR TITLE
feat: support exported file names containing Chinese label

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -95,8 +95,10 @@ export function setFileNameTitle(filePath) {
   const appName = 'LosslessCut';
   document.title = filePath ? `${appName} - ${path.basename(filePath)}` : appName;
 }
-
 export function filenamify(name) {
+  if (i18n.language.startsWith('zh')) {
+    return name.replace(/[^0-9a-zA-Z\u4e00-\u9fa5_.]/g, '_');
+  }
   return name.replace(/[^0-9a-zA-Z_.]/g, '_');
 }
 


### PR DESCRIPTION
When a video segement with a Chinese label it will be replaced with an underscore on export, this PR is used to solve this issue. And maybe other non-English languages need to be handled in this way as well.