### PR TITLE
Add DEB and RPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -419,6 +419,14 @@
           "target": "snap"
         },
         {
+          "arch": ["x64", "armv7l"],
+          "target": "deb"
+        },
+        {
+          "arch": ["x64", "armv7l"],
+          "target": "rpm"
+        },
+        {
           "arch": "arm64",
           "target": "tar.bz2"
         },


### PR DESCRIPTION
This adds builds for Debian and RPM packages, which are better for more permanent installs than AppImage.