### PR TITLE
[PR] Output file timestamp, support inserting variables based on cursor position

### DIFF
--- a/import-export.md
+++ b/import-export.md
@@ -9,6 +9,7 @@ When exporting multiple segments as separate files, LosslessCut offers you the a
 | `${FILENAME}` | The original filename without the extension (e.g. `Beach Trip` for a file named `Beach Trip.mp4`)
 | `${EXT}` | The extension of the file (e.g.: `.mp4`, `.mkv`)
 | `${SEG_NUM}` | Number of the segment (e.g. `1`, `2` or `3`)
+| `${EPOCH_MS}` | Number of milliseconds since epoch (e.g. `1680852771465`)
 | `${SEG_LABEL}` | The label of the segment (e.g. `Getting_Lunch`)
 | `${SEG_SUFFIX}` | If a label exists for this segment, the label will be used, prepended by `-`. Otherwise, the segment number prepended by `-seg` will be used (e.g. `-Getting_Lunch`, `-seg1`)
 | `${CUT_FROM}` | The timestamp for the beginning of the segment in `hh.mm.ss.sss` format (e.g. `00.00.27.184`)

--- a/src/components/OutSegTemplateEditor.jsx
+++ b/src/components/OutSegTemplateEditor.jsx
@@ -94,11 +94,6 @@ const OutSegTemplateEditor = memo(({ outSegTemplate, setOutSegTemplate, generate
 
     const newValue = `${text.slice(0, startPos)}${`\${${variable}}${text.slice(endPos)}`}`;
     setText(newValue);
-
-    // Move the cursor to after the inserted variable
-    const newPos = startPos + variable.length + 2;
-    input.selectionStart = newPos;
-    input.selectionEnd = newPos;
   }, [text]);
 
   return (

--- a/src/util/outputNameTemplate.js
+++ b/src/util/outputNameTemplate.js
@@ -74,6 +74,7 @@ function interpolateSegmentFileName({ template, inputFileNameWithoutExt, segSuff
     EXT: ext,
     SEG_NUM: segNum,
     SEG_LABEL: segLabel,
+    TIMESTAMP: Date.now(),
     CUT_FROM: cutFrom,
     CUT_TO: cutTo,
     SEG_TAGS: {

--- a/src/util/outputNameTemplate.js
+++ b/src/util/outputNameTemplate.js
@@ -66,15 +66,24 @@ export function getOutSegError({ fileNames, filePath, outputDir, safeOutputFileN
 // eslint-disable-next-line no-template-curly-in-string
 export const defaultOutSegTemplate = '${FILENAME}-${CUT_FROM}-${CUT_TO}${SEG_SUFFIX}${EXT}';
 
-function interpolateSegmentFileName({ template, inputFileNameWithoutExt, segSuffix, ext, segNum, segLabel, cutFrom, cutTo, tags }) {
+function interpolateSegmentFileName({ template, inputFileNameWithoutExt, currentTimestamp, segSuffix, ext, segNum, segLabel, cutFrom, cutTo, tags }) {
   const compiled = lodashTemplate(template);
+  if (segSuffix) {
+    if (segNum > 1) {
+      currentTimestamp = Date.now() + 1;
+    } else {
+      currentTimestamp = Date.now();
+    }
+  } else {
+    currentTimestamp = Date.now();
+  }
   const data = {
     FILENAME: inputFileNameWithoutExt,
     SEG_SUFFIX: segSuffix,
     EXT: ext,
     SEG_NUM: segNum,
     SEG_LABEL: segLabel,
-    TIMESTAMP: Date.now(),
+    TIMESTAMP: currentTimestamp,
     CUT_FROM: cutFrom,
     CUT_TO: cutTo,
     SEG_TAGS: {

--- a/src/util/outputNameTemplate.js
+++ b/src/util/outputNameTemplate.js
@@ -65,18 +65,16 @@ export function getOutSegError({ fileNames, filePath, outputDir, safeOutputFileN
 // This is used as a fallback and so it has to always generate unique file names
 // eslint-disable-next-line no-template-curly-in-string
 export const defaultOutSegTemplate = '${FILENAME}-${CUT_FROM}-${CUT_TO}${SEG_SUFFIX}${EXT}';
-
-function interpolateSegmentFileName({ template, inputFileNameWithoutExt, currentTimestamp, segSuffix, ext, segNum, segLabel, cutFrom, cutTo, tags }) {
+let currentTimestamp = Date.now();
+function interpolateSegmentFileName({ template, inputFileNameWithoutExt, segSuffix, ext, segNum, segLabel, cutFrom, cutTo, tags }) {
   const compiled = lodashTemplate(template);
+
   if (segSuffix) {
     if (segNum > 1) {
-      currentTimestamp = Date.now() + 1;
-    } else {
-      currentTimestamp = Date.now();
-    }
-  } else {
-    currentTimestamp = Date.now();
+      currentTimestamp -= 1;
+    } 
   }
+
   const data = {
     FILENAME: inputFileNameWithoutExt,
     SEG_SUFFIX: segSuffix,

--- a/src/util/outputNameTemplate.js
+++ b/src/util/outputNameTemplate.js
@@ -65,15 +65,9 @@ export function getOutSegError({ fileNames, filePath, outputDir, safeOutputFileN
 // This is used as a fallback and so it has to always generate unique file names
 // eslint-disable-next-line no-template-curly-in-string
 export const defaultOutSegTemplate = '${FILENAME}-${CUT_FROM}-${CUT_TO}${SEG_SUFFIX}${EXT}';
-let currentTimestamp = Date.now();
-function interpolateSegmentFileName({ template, inputFileNameWithoutExt, segSuffix, ext, segNum, segLabel, cutFrom, cutTo, tags }) {
-  const compiled = lodashTemplate(template);
 
-  if (segSuffix) {
-    if (segNum > 1) {
-      currentTimestamp += 1;
-    } 
-  }
+function interpolateSegmentFileName({ template, epochMs, inputFileNameWithoutExt, segSuffix, ext, segNum, segLabel, cutFrom, cutTo, tags }) {
+  const compiled = lodashTemplate(template);
 
   const data = {
     FILENAME: inputFileNameWithoutExt,
@@ -81,7 +75,7 @@ function interpolateSegmentFileName({ template, inputFileNameWithoutExt, segSuff
     EXT: ext,
     SEG_NUM: segNum,
     SEG_LABEL: segLabel,
-    TIMESTAMP: currentTimestamp,
+    EPOCH_MS: String(epochMs),
     CUT_FROM: cutFrom,
     CUT_TO: cutTo,
     SEG_TAGS: {
@@ -99,6 +93,8 @@ function formatSegNum(segIndex, segments) {
 }
 
 export function generateOutSegFileNames({ segments, template, forceSafeOutputFileName, formatTimecode, isCustomFormatSelected, fileFormat, filePath, safeOutputFileName, maxLabelLength }) {
+  const currentTimestamp = Date.now();
+
   return segments.map((segment, i) => {
     const { start, end, name = '' } = segment;
     const segNum = formatSegNum(i, segments);
@@ -118,6 +114,7 @@ export function generateOutSegFileNames({ segments, template, forceSafeOutputFil
 
     const segFileName = interpolateSegmentFileName({
       template,
+      epochMs: currentTimestamp + i, // for convenience: give each segment a unique timestamp
       segNum,
       inputFileNameWithoutExt,
       segSuffix: getSegSuffix(),

--- a/src/util/outputNameTemplate.js
+++ b/src/util/outputNameTemplate.js
@@ -71,7 +71,7 @@ function interpolateSegmentFileName({ template, inputFileNameWithoutExt, segSuff
 
   if (segSuffix) {
     if (segNum > 1) {
-      currentTimestamp -= 1;
+      currentTimestamp += 1;
     } 
   }
 


### PR DESCRIPTION
closes https://github.com/mifi/lossless-cut/issues/1524
Referenced Discussion: https://github.com/mifi/lossless-cut/discussions/1520

This PR generates a 13 digit [Unix based timestamp](https://www.unixtimestamp.com/index.php) (to the nearest millisecond), when the "Timestamp" button is clicked. You can leave out the milliseconds to save 3 digits if you want but I thought it is a good safeguard against duplicate filenames.

I also added support to insert variables (when clicking the variable buttons) anywhere in the output file name based on the cursor positioning, using React's useRef.

When multiple segments are present, each segment after the first one has a millisecond added compared to the last segment, to ensure unique identifiers. Adding a millisecond makes the segments' milliseconds go up in the same order as the segNum variable, although to most easily tell the segments apart the user should keep the segSuffix variable.

The timestamp's state is dependent on the output filename's input field; whenever you type something into this field it will re-render the timestamp.

I also considered using a more human-readable timestamp format such as "YYYY-MM-DD HH.MM.SS.milliseconds" but I decided this may be too long of a filename when the original poster wanted a short unique identifier. If you like the more human readable format, consider: https://playcode.io/1392936

Short Demo video: https://i.imgur.com/cmyLmaw.mp4

EDIT to this PR: Edited timestamps to add milliseconds in the case of multiple segments as that makes more sense than subtracting.