### PR TITLE
Fix: Current selected format with size of current selected item.

### DIFF
--- a/src/TopMenu.jsx
+++ b/src/TopMenu.jsx
@@ -31,57 +31,67 @@ const TopMenu = memo(({
   return (
     <div
       className="no-user-select"
-      style={{ background: controlsBackground, transition: darkModeTransition, display: 'flex', alignItems: 'center', padding: '3px 5px', justifyContent: 'space-between', flexWrap: 'wrap' }}
+      style={{
+        background: controlsBackground,
+        transition: darkModeTransition,
+        display: 'flex',
+        alignItems: 'center',
+        padding: '3px 5px',
+        justifyContent: 'space-between',
+        flexWrap: 'wrap' }}
     >
-      {filePath && (
-        <>
-          <Button height={20} iconBefore={ListIcon} onClick={withBlur(() => setStreamsSelectorShown(true))}>
-            {t('Tracks')} ({numStreamsToCopy}/{numStreamsTotal})
-          </Button>
+      {/* Left Buttons */}
+      <div style={{ display: 'flex' }}>
+        {filePath && (
+          <>
+            <Button height={20} iconBefore={ListIcon} onClick={withBlur(() => setStreamsSelectorShown(true))}>
+              {t('Tracks')} ({numStreamsToCopy}/{numStreamsTotal})
+            </Button>
 
-          <Button
-            iconBefore={copyAnyAudioTrack ? VolumeUpIcon : VolumeOffIcon}
+            <Button
+              iconBefore={copyAnyAudioTrack ? VolumeUpIcon : VolumeOffIcon}
+              height={20}
+              title={copyAnyAudioTrack ? t('Keep audio tracks') : t('Discard audio tracks')}
+              onClick={withBlur(toggleStripAudio)}
+            >
+              {copyAnyAudioTrack ? t('Keep audio') : t('Discard audio')}
+            </Button>
+          </>
+        )}
+      </div>
+
+      {/* Right Buttons */}
+      <div style={{ display: 'flex' }}>
+        {showClearWorkingDirButton && (
+          <IconButton
+            intent="danger"
+            icon={CrossIcon}
             height={20}
-            title={copyAnyAudioTrack ? t('Keep audio tracks') : t('Discard audio tracks')}
-            onClick={withBlur(toggleStripAudio)}
-          >
-            {copyAnyAudioTrack ? t('Keep audio') : t('Discard audio')}
-          </Button>
-        </>
-      )}
+            onClick={withBlur(clearOutDir)}
+            title={t('Clear working directory')}
+          />
+        )}
 
-      <div style={{ flexGrow: 1 }} />
-
-      {showClearWorkingDirButton && (
-        <IconButton
-          intent="danger"
-          icon={CrossIcon}
+        <Button
           height={20}
-          onClick={withBlur(clearOutDir)}
-          title={t('Clear working directory')}
-        />
-      )}
+          onClick={withBlur(changeOutDir)}
+          title={customOutDir}
+        >
+          {customOutDir ? t('Working dir set') : t('Working dir unset')}
+        </Button>
 
-      <Button
-        height={20}
-        onClick={withBlur(changeOutDir)}
-        title={customOutDir}
-        paddingLeft={showClearWorkingDirButton ? 4 : undefined}
-      >
-        {customOutDir ? t('Working dir set') : t('Working dir unset')}
-      </Button>
+        {filePath && (
+          <>
+            {renderOutFmt({ height: 20 })}
 
-      {filePath && (
-        <>
-          {renderOutFmt({ height: 20, maxWidth: 100 })}
+            {!simpleMode && (isCustomFormatSelected || outFormatLocked) && renderFormatLock()}
 
-          {!simpleMode && (isCustomFormatSelected || outFormatLocked) && renderFormatLock()}
+            <ExportModeButton selectedSegments={selectedSegments} style={{ flexGrow: 0, flexBasis: 140 }} />
+          </>
+        )}
 
-          <ExportModeButton selectedSegments={selectedSegments} style={{ flexGrow: 0, flexBasis: 140 }} />
-        </>
-      )}
-
-      <IoIosSettings size={24} role="button" onClick={toggleSettings} style={{ verticalAlign: 'middle', marginLeft: 5 }} />
+        <IoIosSettings size={24} role="button" onClick={toggleSettings} style={{ verticalAlign: 'middle', marginLeft: 5 }} />
+      </div>
     </div>
   );
 });

--- a/src/components/OutputFormatSelect.jsx
+++ b/src/components/OutputFormatSelect.jsx
@@ -23,7 +23,12 @@ const OutputFormatSelect = memo(({ style, detectedFileFormat, fileFormat, onOutp
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <Select style={style} value={fileFormat || ''} title={i18n.t('Output format')} onChange={withBlur(e => onOutputFormatUserChange(e.target.value))}>
+    <Select
+      style={{ ...style, width: `${(8 * allOutFormats[fileFormat].length) + 100}px` }}
+      value={fileFormat || ''}
+      title={i18n.t('Output format')}
+      onChange={withBlur(e => onOutputFormatUserChange(e.target.value))}
+    >
       <option key="disabled1" value="" disabled>{i18n.t('Format')}</option>
 
       {detectedFileFormat && (


### PR DESCRIPTION
Hi there, got into this project after seeing the [T3 guy video.
](https://www.youtube.com/live/KPfet1IoH1Q?)
I was thinking about an app that would facilitate this "waterfall" (live -> video -> cuts) content creation flow.

This apps fits a lot on this, and maybe I will try to integrate some of the ideias I have in it.

But as a first contact with this project I notice that the format select was way bigger than necessary, it was keeping some empty space after the end of the selected format. So I tweaked around and could set this format select to be always the size of current selected format.

Hope you like it.