### PR TITLE
Allows semicolons directly after timestamps in timestamp import

### DIFF
--- a/src/edlFormats.js
+++ b/src/edlFormats.js
@@ -189,7 +189,7 @@ export function parseYouTube(str) {
   }
 
   const lines = str.split('\n').map((lineStr) => {
-    const match = lineStr.match(/(?:([0-9]{1,}):)?([0-9]{1,2}):([0-9]{1,2})(?:\.([0-9]{3}))?[\s-]+([^\n]*)$/);
+    const match = lineStr.match(/(?:([0-9]{1,}):)?([0-9]{1,2}):([0-9]{1,2})(?:\.([0-9]{3}))?[\s-:]+([^\n]*)$/);
     return parseLine(match);
   }).filter((line) => line);
 


### PR DESCRIPTION
Fixes #1642, allowing timestamps with semicolons directly after them like `0:00: JDX - Tides (Trailerized)` to be imported.

I have tested it with the two descriptions in #1642, but I'm not sure if this would unexpectedly break the regex or if there is a better way to do it.