### PR TITLE
Fix yarn start finding the ffmpeg binary

### DIFF
--- a/public/ffmpeg.js
+++ b/public/ffmpeg.js
@@ -26,7 +26,14 @@ function getFfPath(cmd) {
   const exeName = isWindows ? `${cmd}.exe` : cmd;
 
   if (customFfPath) return join(customFfPath, exeName);
-  if (isDev) return join('ffmpeg', `${platform}-${arch}/lib`, exeName);
+  
+  if (isDev) {
+    const components = ['ffmpeg'];
+    if (isWindows || isLinux) components.push('lib');
+    components.push(exeName);
+    return join(...components);
+  }
+
   return join(process.resourcesPath, exeName);
 }
 

--- a/public/ffmpeg.js
+++ b/public/ffmpeg.js
@@ -26,9 +26,9 @@ function getFfPath(cmd) {
   const exeName = isWindows ? `${cmd}.exe` : cmd;
 
   if (customFfPath) return join(customFfPath, exeName);
-  
+
   if (isDev) {
-    const components = ['ffmpeg'];
+    const components = ['ffmpeg', `${platform}-${arch}`];
     if (isWindows || isLinux) components.push('lib');
     components.push(exeName);
     return join(...components);

--- a/public/ffmpeg.js
+++ b/public/ffmpeg.js
@@ -26,7 +26,7 @@ function getFfPath(cmd) {
   const exeName = isWindows ? `${cmd}.exe` : cmd;
 
   if (customFfPath) return join(customFfPath, exeName);
-  if (isDev) return join('ffmpeg', `${platform}-${arch}`, exeName);
+  if (isDev) return join('ffmpeg', `${platform}-${arch}/lib`, exeName);
   return join(process.resourcesPath, exeName);
 }
 


### PR DESCRIPTION
Fixes #1722, `yarn start` now functions properly when dependencies are installed and ffmpeg is downloaded using only yarn scripts and no direct user intervention
