### PR TITLE
Fix: tooltips for buttons in tracks selection menu

### DIFF
--- a/src/StreamsSelector.jsx
+++ b/src/StreamsSelector.jsx
@@ -210,7 +210,7 @@ const Stream = memo(({ filePath, stream, onToggle, batchSetCopyStreamIds, copySt
       </td>
 
       <td style={{ display: 'flex', justifyContent: 'flex-end' }}>
-        <IconButton icon={InfoSignIcon} onClick={() => onInfoClick(stream, t('Track {{num}} info', { num: stream.index + 1 }))} appearance="minimal" iconSize={18} />
+        <IconButton icon={InfoSignIcon} title={t('Track {{trackNum}} info', { trackNum: stream.index + 1 })} onClick={() => onInfoClick(stream, t('Track {{trackNum}} info', { trackNum: stream.index + 1 }))} appearance="minimal" iconSize={18} />
 
         <Popover
           position={Position.BOTTOM_LEFT}
@@ -254,12 +254,12 @@ const FileHeading = ({ path, formatData, chapters, onTrashClick, onEditClick, se
 
       <div style={{ flexGrow: 1 }} />
 
-      <IconButton icon={InfoSignIcon} onClick={() => onInfoClick(formatData, t('File info'))} appearance="minimal" iconSize={18} />
+      <IconButton icon={InfoSignIcon} title={t('File info')} onClick={() => onInfoClick(formatData, t('File info'))} appearance="minimal" iconSize={18} />
       {chapters && chapters.length > 0 && <IconButton icon={BookIcon} onClick={() => onInfoClick(chapters, t('Chapters'))} appearance="minimal" iconSize={18} />}
-      {onEditClick && <IconButton icon={EditIcon} onClick={onEditClick} appearance="minimal" iconSize={18} />}
+      {onEditClick && <IconButton icon={EditIcon} title={t('Edit file metadata')} onClick={onEditClick} appearance="minimal" iconSize={18} />}
       {onTrashClick && <IconButton icon={TrashIcon} onClick={onTrashClick} appearance="minimal" iconSize={18} />}
-      <IconButton iconSize={18} color="#52BD95" icon={FaCheckCircle} onClick={() => setCopyAllStreams(true)} appearance="minimal" />
-      <IconButton iconSize={18} color="#D14343" icon={FaBan} onClick={() => setCopyAllStreams(false)} appearance="minimal" />
+      <IconButton iconSize={18} color="#52BD95" icon={FaCheckCircle} title={t('Keep all tracks')} onClick={() => setCopyAllStreams(true)} appearance="minimal" />
+      <IconButton iconSize={18} color="#D14343" icon={FaBan} title={t('Discard all tracks')} onClick={() => setCopyAllStreams(false)} appearance="minimal" />
       {onExtractAllStreamsPress && <IconButton iconSize={16} title={t('Export each track as individual files')} icon={ForkIcon} onClick={onExtractAllStreamsPress} appearance="minimal" />}
     </div>
   );

--- a/src/StreamsSelector.jsx
+++ b/src/StreamsSelector.jsx
@@ -333,7 +333,7 @@ const StreamsSelector = memo(({
 
   return (
     <>
-      <p style={{ margin: '.5em 1em' }}>{t('Click to select which tracks to keep when exporting:')}</p>
+      <p style={{ margin: '.5em 2em .5em 1em' }}>{t('Click to select which tracks to keep when exporting:')}</p>
 
       <div style={fileStyle}>
         {/* We only support editing main file metadata for now */}


### PR DESCRIPTION
Adds tooltips for buttons in the tracks selection menu that were missing mouseover tooltips as well as an adjustment to the right margin for the title text so it doesn't overlap with the exit/close button.

![image](https://github.com/mifi/lossless-cut/assets/25272162/caa50acd-b9a0-48de-a681-be82eddc90b7)

![image](https://github.com/mifi/lossless-cut/assets/25272162/fa1cace8-3445-4688-a1ad-472bbbd83d68)

### Changelog
- "Edit file metadata" tooltip
- "Keep all tracks" tooltip
- "Discard all tracks" tooltip
- "Track # info" tooltip for each track
- Tracks selection menu title text's right margin was adjusted to `2em` to be consistent with the title text in the settings menu.
