### PR TITLE
Add cutlist (OTR) import option

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -70,6 +70,12 @@ export default ({ app, mainWindow, newVersion, isStoreBuild }: {
               },
             },
             {
+              label: esc(t('Cutlist')),
+              click() {
+                mainWindow.webContents.send('importEdlFile', 'cutlist');
+              },
+            },
+            {
               label: esc(t('EDL (MPlayer)')),
               click() {
                 mainWindow.webContents.send('importEdlFile', 'mplayer');

--- a/src/renderer/src/edlFormats.test.ts
+++ b/src/renderer/src/edlFormats.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import { it, describe, expect } from 'vitest';
 
 
-import { parseSrt, formatSrt, parseYouTube, formatYouTube, parseMplayerEdl, parseXmeml, parseFcpXml, parseCsv, parseCsvTime, getFrameValParser, formatCsvFrames, getFrameCountRaw, parsePbf, parseDvAnalyzerSummaryTxt } from './edlFormats';
+import { parseSrt, formatSrt, parseYouTube, formatYouTube, parseMplayerEdl, parseXmeml, parseFcpXml, parseCsv, parseCsvTime, getFrameValParser, formatCsvFrames, getFrameCountRaw, parsePbf, parseDvAnalyzerSummaryTxt, parseCutlist } from './edlFormats';
 
 // eslint-disable-next-line no-underscore-dangle
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -239,6 +239,62 @@ it('parses csv with timestamps', async () => {
     { end: 1, name: 'D', start: 0 },
     { end: 1.99, name: 'E', start: 1.01 },
     { start: 2, name: 'F', end: 3 },
+  ]);
+});
+
+const cutlistStr = `
+[General]
+Application=SomeApplication.exe
+Version=0.0.0.1
+FramesPerSecond=25
+IntendedCutApplicationName=SomeApplication
+IntendedCutApplication=SomeApplication.exe
+VDUseSmartRendering=1
+IntendedCutApplicationVersion=1.7.8
+comment1=The following parts of the movie will be kept, the rest will be cut out.
+comment2=All values are given in seconds.
+NoOfCuts=2
+ApplyToFile=Some_File_Name.avi
+OriginalFileSizeBytes=123456
+
+[Cut0]
+Start=849.12
+StartFrame=21228
+Duration=1881.84
+DurationFrames=47046
+
+[Cut1]
+Start=3147.72
+StartFrame=78693
+Duration=944.6
+DurationFrames=23615
+
+[Info]
+Author=AuthorName
+RatingByAuthor=0
+EPGError=0
+ActualContent=
+MissingBeginning=0
+MissingEnding=0
+MissingVideo=0
+MissingAudio=0
+OtherError=0
+OtherErrorDescription=
+SuggestedMovieName=
+UserComment=cutted with XXXX
+
+[Meta]
+CutlistId=12345
+GeneratedOn=1900-01-01 00:00:01
+GeneratedBy=cutlist v0.0.0
+`;
+
+it('parses cutlist', async () => {
+  const parsed = await parseCutlist(cutlistStr);
+
+  expect(parsed).toEqual([
+    { end: 2730.96, name: 'Cut 0', start: 849.12 },
+    { end: 4092.32, name: 'Cut 1', start: 3147.72 },
   ]);
 });
 

--- a/src/renderer/src/edlStore.ts
+++ b/src/renderer/src/edlStore.ts
@@ -2,7 +2,7 @@ import JSON5 from 'json5';
 import i18n from 'i18next';
 import type { parse as CueParse } from 'cue-parser';
 
-import { parseSrt, formatSrt, parseCuesheet, parseXmeml, parseFcpXml, parseCsv, parsePbf, parseMplayerEdl, formatCsvHuman, formatTsv, formatCsvFrames, formatCsvSeconds, parseCsvTime, getFrameValParser, parseDvAnalyzerSummaryTxt } from './edlFormats';
+import { parseSrt, formatSrt, parseCuesheet, parseXmeml, parseFcpXml, parseCsv, parseCutlist, parsePbf, parseMplayerEdl, formatCsvHuman, formatTsv, formatCsvFrames, formatCsvSeconds, parseCsvTime, getFrameValParser, parseDvAnalyzerSummaryTxt } from './edlFormats';
 import { askForYouTubeInput, showOpenDialog } from './dialogs';
 import { getOutPath } from './util';
 import { EdlExportType, EdlFileType, EdlImportType, Segment, StateSegment } from './types';
@@ -20,6 +20,10 @@ export async function loadCsvSeconds(path: string) {
 export async function loadCsvFrames(path: string, fps?: number) {
   if (!fps) throw new Error('The loaded file has an unknown framerate');
   return parseCsv(await readFile(path, 'utf8'), getFrameValParser(fps));
+}
+
+export async function loadCutlistSeconds(path: string) {
+  return parseCutlist(await readFile(path, 'utf8'));
 }
 
 export async function loadXmeml(path: string) {
@@ -96,6 +100,7 @@ export async function loadLlcProject(path: string) {
 export async function readEdlFile({ type, path, fps }: { type: EdlFileType, path: string, fps?: number | undefined }) {
   if (type === 'csv') return loadCsvSeconds(path);
   if (type === 'csv-frames') return loadCsvFrames(path, fps);
+  if (type === 'cutlist') return loadCutlistSeconds(path);
   if (type === 'xmeml') return loadXmeml(path);
   if (type === 'fcpxml') return loadFcpXml(path);
   if (type === 'dv-analyzer-summary-txt') return loadDvAnalyzerSummaryTxt(path);

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -61,7 +61,7 @@ export interface InverseCutSegment {
 
 export type PlaybackMode = 'loop-segment-start-end' | 'loop-segment' | 'play-segment-once' | 'loop-selected-segments';
 
-export type EdlFileType = 'csv' | 'csv-frames' | 'xmeml' | 'fcpxml' | 'dv-analyzer-summary-txt' | 'cue' | 'pbf' | 'mplayer' | 'srt' | 'llc';
+export type EdlFileType = 'csv' | 'csv-frames' | 'cutlist' | 'xmeml' | 'fcpxml' | 'dv-analyzer-summary-txt' | 'cue' | 'pbf' | 'mplayer' | 'srt' | 'llc';
 
 export type EdlImportType = 'youtube' | EdlFileType;
 


### PR DESCRIPTION
There was already an feature request some time ago: https://github.com/mifi/lossless-cut/issues/1771

Cutlist (cutlist.at) is a (a bit strage) cut file format which is mainly used by OnlineTvRecorder (OTR).
This PR will add the possibility to import such a cutlist into lossless-cut.