### PR TITLE
true keyframe cut

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -260,6 +260,7 @@
   "Exit": "Exit",
   "Expand segments +5 sec": "Expand segments +5 sec",
   "Expected": "Expected",
+  "Experimental keyframe cut": "Experimental keyframe cut",
   "Export": "Export",
   "Export {{ num }} segments": "Export {{ num }} segments",
   "Export each segment to a separate file": "Export each segment to a separate file",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -30,6 +30,7 @@ export interface Config {
   enableCustomOutDir: boolean,
   recentCustomOutDirs: string[],
   keyframeCut: boolean,
+  autoKeyframeCutFix: boolean,
   autoMerge: boolean,
   autoDeleteMergedSegments: boolean,
   segmentsToChaptersOnly: boolean,

--- a/src/main/configStore.ts
+++ b/src/main/configStore.ts
@@ -102,6 +102,7 @@ const defaults: Config = {
   enableCustomOutDir: false,
   recentCustomOutDirs: [],
   keyframeCut: true,
+  autoKeyframeCutFix: false,
   autoMerge: false,
   autoDeleteMergedSegments: true,
   segmentsToChaptersOnly: false,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -189,8 +189,8 @@ function App() {
   const [selectedBatchFiles, setSelectedBatchFiles] = useState<string[]>([]);
 
   const allUserSettings = useUserSettingsRoot();
-  const { captureFormat, keyframeCut, preserveMetadata, preserveMetadataOnMerge, preserveMovData, preserveChapters, movFastStart, avoidNegativeTs, autoMerge, timecodeFormat, invertCutSegments, autoExportExtraStreams, askBeforeClose, enableImportChapters, enableAskForFileOpenAction, playbackVolume, autoSaveProjectFile, wheelSensitivity, waveformHeight, invertTimelineScroll, language, ffmpegExperimental, hideNotifications, hideOsNotifications, autoLoadTimecode, autoDeleteMergedSegments, exportConfirmEnabled, segmentsToChapters, simpleMode, cutFileTemplate, cutMergedFileTemplate, mergedFileTemplate, keyboardSeekAccFactor, keyboardNormalSeekSpeed, keyboardSeekSpeed2, keyboardSeekSpeed3, treatInputFileModifiedTimeAsStart, treatOutputFileModifiedTimeAsStart, outFormatLocked, safeOutputFileName, enableAutoHtml5ify, segmentsToChaptersOnly, keyBindings, enableSmartCut, customFfPath, storeProjectInWorkingDir, enableOverwriteOutput, mouseWheelZoomModifierKey, mouseWheelFrameSeekModifierKey, mouseWheelKeyframeSeekModifierKey, captureFrameMethod, captureFrameQuality, captureFrameFileNameFormat, enableNativeHevc, cleanupChoices, darkMode, preferStrongColors, outputFileNameMinZeroPadding, cutFromAdjustmentFrames, cutToAdjustmentFrames, waveformMode: waveformModePreference, thumbnailsEnabled, keyframesEnabled, reducedMotion, ffmpegHwaccel } = allUserSettings.settings;
-  const { setCaptureFormat, setCustomOutDir, setKeyframeCut, setPlaybackVolume, setExportConfirmEnabled, setSimpleMode, setOutFormatLocked, setSafeOutputFileName, setKeyBindings, resetKeyBindings, setStoreProjectInWorkingDir, setCleanupChoices, toggleDarkMode, setWaveformMode, setThumbnailsEnabled, setKeyframesEnabled, prefersReducedMotion, customOutDir } = allUserSettings;
+  const { captureFormat, keyframeCut, preserveMetadata, preserveMetadataOnMerge, preserveMovData, preserveChapters, movFastStart, avoidNegativeTs, autoMerge, timecodeFormat, invertCutSegments, autoExportExtraStreams, askBeforeClose, enableImportChapters, enableAskForFileOpenAction, playbackVolume, autoSaveProjectFile, wheelSensitivity, waveformHeight, invertTimelineScroll, language, ffmpegExperimental, hideNotifications, hideOsNotifications, autoLoadTimecode, autoDeleteMergedSegments, exportConfirmEnabled, segmentsToChapters, simpleMode, cutFileTemplate, cutMergedFileTemplate, mergedFileTemplate, keyboardSeekAccFactor, keyboardNormalSeekSpeed, keyboardSeekSpeed2, keyboardSeekSpeed3, treatInputFileModifiedTimeAsStart, treatOutputFileModifiedTimeAsStart, outFormatLocked, safeOutputFileName, enableAutoHtml5ify, segmentsToChaptersOnly, keyBindings, enableSmartCut, customFfPath, storeProjectInWorkingDir, enableOverwriteOutput, mouseWheelZoomModifierKey, mouseWheelFrameSeekModifierKey, mouseWheelKeyframeSeekModifierKey, captureFrameMethod, captureFrameQuality, captureFrameFileNameFormat, enableNativeHevc, cleanupChoices, darkMode, preferStrongColors, outputFileNameMinZeroPadding, cutFromAdjustmentFrames, cutToAdjustmentFrames, autoKeyframeCutFix, waveformMode: waveformModePreference, thumbnailsEnabled, keyframesEnabled, reducedMotion, ffmpegHwaccel } = allUserSettings.settings;
+  const { settings, setCaptureFormat, setCustomOutDir, setKeyframeCut, setPlaybackVolume, setExportConfirmEnabled, setSimpleMode, setOutFormatLocked, setSafeOutputFileName, setKeyBindings, resetKeyBindings, setStoreProjectInWorkingDir, setCleanupChoices, toggleDarkMode, setWaveformMode, setThumbnailsEnabled, setKeyframesEnabled, prefersReducedMotion, customOutDir } = allUserSettings;
 
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(!simpleMode);
 
@@ -592,7 +592,7 @@ function App() {
 
   const {
     concatFiles, html5ifyDummy, cutMultiple, concatCutSegments, html5ify, fixInvalidDuration, decimate, extractStreams, tryDeleteFiles,
-  } = useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, treatOutputFileModifiedTimeAsStart, isEncoding, lossyMode, enableOverwriteOutput, outputPlaybackRate, cutFromAdjustmentFrames, cutToAdjustmentFrames, appendLastCommandsLog, encCustomBitrate: encBitrate, appendFfmpegCommandLog, ffmpegHwaccel });
+  } = useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, treatOutputFileModifiedTimeAsStart, isEncoding, lossyMode, enableOverwriteOutput, outputPlaybackRate, cutFromAdjustmentFrames, cutToAdjustmentFrames, autoKeyframeCutFix, appendLastCommandsLog, encCustomBitrate: encBitrate, appendFfmpegCommandLog, ffmpegHwaccel });
 
   const { previewFilePath, setPreviewFilePath, usingDummyVideo, setUsingDummyVideo, userHtml5ifyCurrentFile, convertFormatBatch, html5ifyAndLoadWithPreferences } = useHtml5ify({
     filePath, hasVideo, hasAudio, workingRef, setWorking, ensureWritableOutDir, customOutDir, batchFiles, enableAutoHtml5ify, setProgress, html5ify, html5ifyDummy, withErrorHandling, showGenericDialog,
@@ -1132,6 +1132,7 @@ function App() {
         paramsByFile,
         chapters: chaptersToAdd,
         detectedFps,
+        autoKeyframeCutFix,
       });
 
       let mergedOutFilePath: string | undefined;

--- a/src/renderer/src/components/ExportConfirm.tsx
+++ b/src/renderer/src/components/ExportConfirm.tsx
@@ -173,7 +173,7 @@ function ExportConfirm({
 }) {
   const { t } = useTranslation();
 
-  const { keyframeCut, toggleKeyframeCut, preserveMovData, setPreserveMovData, preserveMetadata, setPreserveMetadata, preserveChapters, setPreserveChapters, movFastStart, setMovFastStart, avoidNegativeTs, setAvoidNegativeTs, autoDeleteMergedSegments, exportConfirmEnabled, toggleExportConfirmEnabled, segmentsToChapters, setSegmentsToChapters, preserveMetadataOnMerge, setPreserveMetadataOnMerge, enableSmartCut, setEnableSmartCut, effectiveExportMode, enableOverwriteOutput, setEnableOverwriteOutput, ffmpegExperimental, setFfmpegExperimental, cutFromAdjustmentFrames, setCutFromAdjustmentFrames, cutToAdjustmentFrames, setCutToAdjustmentFrames, setCutFileTemplate, setCutMergedFileTemplate, simpleMode, keyframesEnabled } = useUserSettings();
+  const { keyframeCut, toggleKeyframeCut, preserveMovData, setPreserveMovData, preserveMetadata, setPreserveMetadata, preserveChapters, setPreserveChapters, movFastStart, setMovFastStart, avoidNegativeTs, setAvoidNegativeTs, autoDeleteMergedSegments, exportConfirmEnabled, toggleExportConfirmEnabled, segmentsToChapters, setSegmentsToChapters, preserveMetadataOnMerge, setPreserveMetadataOnMerge, enableSmartCut, setEnableSmartCut, effectiveExportMode, enableOverwriteOutput, setEnableOverwriteOutput, ffmpegExperimental, setFfmpegExperimental, cutFromAdjustmentFrames, setCutFromAdjustmentFrames, cutToAdjustmentFrames, setCutToAdjustmentFrames, setCutFileTemplate, setCutMergedFileTemplate, simpleMode, keyframesEnabled, autoKeyframeCutFix, setAutoKeyframeCutFix } = useUserSettings();
 
   const [showAdvanced, setShowAdvanced] = useState(!simpleMode);
 
@@ -182,6 +182,7 @@ function ExportConfirm({
   const toggleMovFastStart = useCallback(() => setMovFastStart((val) => !val), [setMovFastStart]);
   const toggleSegmentsToChapters = useCallback(() => setSegmentsToChapters((v) => !v), [setSegmentsToChapters]);
   const togglePreserveMetadataOnMerge = useCallback(() => setPreserveMetadataOnMerge((v) => !v), [setPreserveMetadataOnMerge]);
+  const toggleAutoKeyframeCutFix = useCallback(() => setAutoKeyframeCutFix((val) => !val), [setAutoKeyframeCutFix]);
 
   const isMov = ffmpegIsMov(outFormat);
   const isIpod = outFormat === 'ipod';
@@ -324,6 +325,10 @@ function ExportConfirm({
 
   const onCutFromAdjustmentFramesHelpPress = useCallback(() => {
     showHelpText({ text: i18n.t('This option allows you to shift all segment start times forward by one or more frames before cutting. This can be useful if the output video starts from the wrong (preceding) keyframe.') });
+  }, [showHelpText]);
+
+  const onAutoKeyframeCutFixHelpPress = useCallback(() => {
+    showHelpText({ text: i18n.t('Automatically align segment start times to keyframes before export. This ensures clean cuts without re-encoding by finding the actual keyframes in the video file.') });
   }, [showHelpText]);
 
   const onFfmpegExperimentalHelpPress = useCallback(() => {
@@ -507,6 +512,17 @@ function ExportConfirm({
                       <ShiftTimes values={adjustCutToValues} num={cutToAdjustmentFrames} setNum={setCutToAdjustmentFrames} />
                     </td>
                     <td />
+                  </AnimatedTr>
+                  <AnimatedTr>
+                    <td>
+                      {t('Auto keyframe cut fix')}
+                    </td>
+                    <td>
+                      <Switch checked={autoKeyframeCutFix} onCheckedChange={toggleAutoKeyframeCutFix} />
+                    </td>
+                    <td>
+                      <HelpIcon onClick={onAutoKeyframeCutFixHelpPress} />
+                    </td>
                   </AnimatedTr>
                 </>
               )}

--- a/src/renderer/src/dialogs/index.tsx
+++ b/src/renderer/src/dialogs/index.tsx
@@ -294,16 +294,16 @@ export async function askForAlignSegments() {
   const startOrEnd = await askForSegmentsStartOrEnd(i18n.t('Do you want to align the segment start or end timestamps to keyframes?'));
   if (startOrEnd == null) return undefined;
 
-  const { value: mode } = await getSwal().Swal.fire<FindKeyframeMode | 'opposing'>({
+  const { value: mode } = await getSwal().Swal.fire<FindKeyframeMode>({
     input: 'radio',
     showCancelButton: true,
     inputOptions: {
       nearest: i18n.t('Nearest keyframe'),
       before: i18n.t('Previous keyframe'),
       after: i18n.t('Next keyframe'),
-      opposing: i18n.t('Segment start to previous keyframe and end to next keyframe'),
-    } satisfies Record<FindKeyframeMode | 'opposing', unknown>,
-    inputValue: 'before',
+      keyframeCutFix: i18n.t('True keyframe cut'),
+    } satisfies Record<FindKeyframeMode, unknown>,
+    inputValue: 'keyframeCutFix',
     text: i18n.t('Do you want to align segment times to the nearest, previous or next keyframe?'),
   });
 

--- a/src/renderer/src/dialogs/index.tsx
+++ b/src/renderer/src/dialogs/index.tsx
@@ -301,9 +301,9 @@ export async function askForAlignSegments() {
       nearest: i18n.t('Nearest keyframe'),
       before: i18n.t('Previous keyframe'),
       after: i18n.t('Next keyframe'),
-      keyframeCutFix: i18n.t('True keyframe cut'),
       opposing: i18n.t('Segment start to previous keyframe and end to next keyframe'),
-    } satisfies Record<FindKeyframeMode, unknown>,
+      experimental: i18n.t('Experimental keyframe cut'),
+    } satisfies Record<FindKeyframeMode | 'opposing', unknown>,
     inputValue: 'before',
     text: i18n.t('Do you want to align segment times to the nearest, previous or next keyframe?'),
   });

--- a/src/renderer/src/dialogs/index.tsx
+++ b/src/renderer/src/dialogs/index.tsx
@@ -302,8 +302,9 @@ export async function askForAlignSegments() {
       before: i18n.t('Previous keyframe'),
       after: i18n.t('Next keyframe'),
       keyframeCutFix: i18n.t('True keyframe cut'),
+      opposing: i18n.t('Segment start to previous keyframe and end to next keyframe'),
     } satisfies Record<FindKeyframeMode, unknown>,
-    inputValue: 'keyframeCutFix',
+    inputValue: 'before',
     text: i18n.t('Do you want to align segment times to the nearest, previous or next keyframe?'),
   });
 

--- a/src/renderer/src/ffmpeg.ts
+++ b/src/renderer/src/ffmpeg.ts
@@ -109,7 +109,7 @@ export const findNextKeyframe = (keyframes: Frame[], time: number) => keyframes.
 const findPreviousKeyframe = (keyframes: Frame[], time: number) => keyframes.findLast((keyframe) => keyframe.time <= time);
 const findNearestKeyframe = (keyframes: Frame[], time: number) => minBy(keyframes, (keyframe) => Math.abs(keyframe.time - time));
 
-export type FindKeyframeMode = 'nearest' | 'before' | 'after' | 'keyframeCutFix';
+export type FindKeyframeMode = 'nearest' | 'before' | 'after' | 'keyframeCutFix' | 'opposing';
 
 function findKeyframe(keyframes: Frame[], time: number, mode: FindKeyframeMode) {
   switch (mode) {

--- a/src/renderer/src/ffmpeg.ts
+++ b/src/renderer/src/ffmpeg.ts
@@ -109,7 +109,7 @@ export const findNextKeyframe = (keyframes: Frame[], time: number) => keyframes.
 const findPreviousKeyframe = (keyframes: Frame[], time: number) => keyframes.findLast((keyframe) => keyframe.time <= time);
 const findNearestKeyframe = (keyframes: Frame[], time: number) => minBy(keyframes, (keyframe) => Math.abs(keyframe.time - time));
 
-export type FindKeyframeMode = 'nearest' | 'before' | 'after';
+export type FindKeyframeMode = 'nearest' | 'before' | 'after' | 'keyframeCutFix';
 
 function findKeyframe(keyframes: Frame[], time: number, mode: FindKeyframeMode) {
   switch (mode) {
@@ -121,6 +121,9 @@ function findKeyframe(keyframes: Frame[], time: number, mode: FindKeyframeMode) 
     }
     case 'after': {
       return findNextKeyframe(keyframes, time);
+    }
+    case 'keyframeCutFix': {
+      return findNextKeyframe(keyframes,time);
     }
     default: {
       return undefined;

--- a/src/renderer/src/ffmpeg.ts
+++ b/src/renderer/src/ffmpeg.ts
@@ -109,7 +109,7 @@ export const findNextKeyframe = (keyframes: Frame[], time: number) => keyframes.
 const findPreviousKeyframe = (keyframes: Frame[], time: number) => keyframes.findLast((keyframe) => keyframe.time <= time);
 const findNearestKeyframe = (keyframes: Frame[], time: number) => minBy(keyframes, (keyframe) => Math.abs(keyframe.time - time));
 
-export type FindKeyframeMode = 'nearest' | 'before' | 'after' | 'keyframeCutFix' | 'opposing';
+export type FindKeyframeMode = 'nearest' | 'before' | 'after' | 'experimental' | 'opposing';
 
 function findKeyframe(keyframes: Frame[], time: number, mode: FindKeyframeMode) {
   switch (mode) {
@@ -122,8 +122,8 @@ function findKeyframe(keyframes: Frame[], time: number, mode: FindKeyframeMode) 
     case 'after': {
       return findNextKeyframe(keyframes, time);
     }
-    case 'keyframeCutFix': {
-      return findNextKeyframe(keyframes,time);
+    case 'experimental': {
+      return findNextKeyframe(keyframes, time);
     }
     default: {
       return undefined;

--- a/src/renderer/src/hooks/useFfmpegOperations.ts
+++ b/src/renderer/src/hooks/useFfmpegOperations.ts
@@ -5,7 +5,7 @@ import invariant from 'tiny-invariant';
 import i18n from 'i18next';
 
 import { getSuffixedOutPath, transferTimestamps, getOutFileExtension, getOutDir, getHtml5ifiedPath, unlinkWithRetry, getFrameDuration, isMac, html5ifiedPrefix, html5dummySuffix, assertFileExists } from '../util';
-import { isCuttingStart, isCuttingEnd, runFfmpegWithProgress, getFfCommandLine, getDuration, createChaptersFromSegments, readFileFfprobeMeta, getExperimentalArgs, getVideoTimescaleArgs, logStdoutStderr, runFfmpegConcat, RefuseOverwriteError, runFfmpeg } from '../ffmpeg';
+import { isCuttingStart, isCuttingEnd, runFfmpegWithProgress, getFfCommandLine, getDuration, createChaptersFromSegments, readFileFfprobeMeta, getExperimentalArgs, getVideoTimescaleArgs, logStdoutStderr, runFfmpegConcat, RefuseOverwriteError, runFfmpeg, findKeyframeNearTime, getStreamFps } from '../ffmpeg';
 import { getMapStreamsArgs, getStreamIdsToCopy } from '../util/streams';
 import { needsSmartCut, getCodecParams } from '../smartcut';
 import { getGuaranteedSegments, isDurationValid } from '../segments';
@@ -79,7 +79,7 @@ export async function maybeMkDeepOutDir({ outputDir, fileOutPath }: { outputDir:
 }
 
 
-function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, treatOutputFileModifiedTimeAsStart, isEncoding, lossyMode, enableOverwriteOutput, outputPlaybackRate, cutFromAdjustmentFrames, cutToAdjustmentFrames, appendLastCommandsLog, encCustomBitrate, appendFfmpegCommandLog, ffmpegHwaccel }: {
+function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, treatOutputFileModifiedTimeAsStart, isEncoding, lossyMode, enableOverwriteOutput, outputPlaybackRate, cutFromAdjustmentFrames, cutToAdjustmentFrames, autoKeyframeCutFix, appendLastCommandsLog, encCustomBitrate, appendFfmpegCommandLog, ffmpegHwaccel }: {
   filePath: string | undefined,
   treatInputFileModifiedTimeAsStart: boolean,
   treatOutputFileModifiedTimeAsStart: boolean | null | undefined,
@@ -89,6 +89,7 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
   outputPlaybackRate: number,
   cutFromAdjustmentFrames: number,
   cutToAdjustmentFrames: number,
+  autoKeyframeCutFix: boolean,
   appendLastCommandsLog: (a: string) => void,
   encCustomBitrate: number | undefined,
   appendFfmpegCommandLog: (args: string[]) => void,
@@ -546,7 +547,7 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
   }, [appendFfmpegCommandLog, filePath]);
 
   const cutMultiple = useCallback(async ({
-    outputDir, customOutDir, segments: segmentsIn, cutFileNames, fileDuration, rotation, detectedFps, onProgress: onTotalProgress, keyframeCut, copyFileStreams, allFilesMeta, outFormat, shortestFlag, ffmpegExperimental, preserveMetadata, preserveMetadataOnMerge, preserveMovData, preserveChapters, movFastStart, avoidNegativeTs, paramsByFile, chapters,
+    outputDir, customOutDir, segments: segmentsIn, cutFileNames, fileDuration, rotation, detectedFps, onProgress: onTotalProgress, keyframeCut, copyFileStreams, allFilesMeta, outFormat, shortestFlag, ffmpegExperimental, preserveMetadata, preserveMetadataOnMerge, preserveMovData, preserveChapters, movFastStart, avoidNegativeTs, paramsByFile, chapters, autoKeyframeCutFix,
   }: {
     outputDir: string,
     customOutDir: string | undefined,
@@ -570,10 +571,48 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
     avoidNegativeTs: AvoidNegativeTs | undefined,
     paramsByFile: ParamsByFile,
     chapters: Chapter[] | undefined,
+    autoKeyframeCutFix: boolean,
   }) => {
     console.log('paramsByFile', paramsByFile);
 
-    const segments = getGuaranteedSegments(segmentsIn, fileDuration);
+    let segments = getGuaranteedSegments(segmentsIn, fileDuration);
+
+    // Auto-align segment start times to keyframes if enabled
+    console.log('autoKeyframeCutFix:', autoKeyframeCutFix, 'filePath:', filePath);
+    if (autoKeyframeCutFix && filePath) {
+      const { streams } = allFilesMeta[filePath]!;
+      const videoStream = streams.find((s) => s.codec_type === 'video');
+      console.log('videoStream:', videoStream);
+      if (videoStream) {
+        const frameTime = 1 / (getStreamFps(videoStream as FFprobeStream) || 1000);
+        console.log('Before alignment - segments:', segments.map(s => ({ start: s.start, end: s.end })));
+        const alignedSegments = await pMap(segments, async (segment) => {
+          const newSegment = { ...segment };
+          // Find keyframe near start time using keyframeCutFix mode (next keyframe)
+          let keyframe = await findKeyframeNearTime({ filePath, streamIndex: videoStream.index, time: segment.start, mode: 'keyframeCutFix' });
+          console.log('Initial keyframe search for', segment.start, '->', keyframe);
+          if (keyframe === undefined) {
+            keyframe = fileDuration;
+          }
+          // Apply keyframeCutFix adjustments: +0.3 frames, find keyframe, -0.7 frames
+          const adjustedTime = segment.start + frameTime * 0.3;
+          keyframe = await findKeyframeNearTime({ filePath, streamIndex: videoStream.index, time: adjustedTime, mode: 'keyframeCutFix' });
+          console.log('Adjusted keyframe search for', adjustedTime, '->', keyframe);
+          if (keyframe === undefined) {
+            keyframe = fileDuration;
+          }
+          newSegment.start = keyframe - frameTime * 0.7;
+          console.log('New segment start:', newSegment.start);
+          // Ensure segment is valid
+          if (newSegment.end != null) {
+            newSegment.start = Math.min(newSegment.start, newSegment.end - frameTime * 0.99);
+          }
+          return newSegment;
+        }, { concurrency: 1 });
+        console.log('After alignment - segments:', alignedSegments.map(s => ({ start: s.start, end: s.end })));
+        segments = alignedSegments;
+      }
+    }
 
     const singleProgresses: Record<number, number> = {};
     function onSingleProgress(id: number, singleProgress: number) {

--- a/src/renderer/src/hooks/useSegments.tsx
+++ b/src/renderer/src/hooks/useSegments.tsx
@@ -8,8 +8,7 @@ import sortBy from 'lodash/sortBy';
 import { Trans, useTranslation } from 'react-i18next';
 import { FaLink } from 'react-icons/fa';
 
-import TextInput from '../components/TextInput';
-import { detectSceneChanges as ffmpegDetectSceneChanges, readFrames, mapTimesToSegments, findKeyframeNearTime } from '../ffmpeg';
+import { detectSceneChanges as ffmpegDetectSceneChanges, readFrames, mapTimesToSegments, findKeyframeNearTime, getStreamFps } from '../ffmpeg';
 import { getFileSize, shuffleArray } from '../util';
 import { errorToast } from '../swal';
 import { createNumSegments as createNumSegmentsDialog, createFixedByteSixedSegments as createFixedByteSixedSegmentsDialog, createRandomSegments as createRandomSegmentsDialog, labelSegmentDialog, askForAlignSegments, selectSegmentsByLabelDialog, askForSegmentDuration, toastError } from '../dialogs';
@@ -502,25 +501,50 @@ function useSegments({ filePath, workingRef, setWorking, setProgress, videoStrea
       if (response == null) return;
       setWorking({ text: i18n.t('Aligning segments to keyframes') });
       const { mode, startOrEnd } = response;
+
+      if (filePath == null) throw new Error();
+      const frameTime = 1 / (getStreamFps(videoStream) || 1000);
+
       await modifySelectedSegmentTimes(async (segment) => {
         const newSegment = { ...segment };
 
-        const align = async (key: 'start' | 'end') => {
+        async function align(key: string) {
           const time = newSegment[key];
           invariant(filePath != null);
           if (time != null) {
-            const keyframe = await findKeyframeNearTime({
-              filePath,
-              streamIndex: videoStream.index,
-              time,
-              mode: mode === 'opposing' ? (key === 'start' ? 'before' : 'after') : mode,
-            });
-            if (keyframe == null) throw new UserFacingError(i18n.t('Cannot find any keyframe within 60 seconds of frame {{time}}', { time }));
+            let keyframe = await findKeyframeNearTime({ filePath, streamIndex: videoStream.index, time, mode });
+            if (keyframe === undefined) {
+              if (mode !== 'keyframeCutFix') {
+                throw new UserFacingError(i18n.t('Cannot find any keyframe within 60 seconds of frame {{time}}', { time }));
+              }
+              keyframe = fileDuration;
+              console.log(2,time,keyframe);
+            }
             newSegment[key] = keyframe;
           }
-        };
-        if (startOrEnd.includes('start')) await align('start');
-        if (startOrEnd.includes('end')) await align('end');
+        }
+        if (startOrEnd.includes('start')) {
+          if (mode === 'keyframeCutFix') {
+            newSegment.start += frameTime * 0.3;
+          }
+          await align('start');
+          if (mode === 'keyframeCutFix') {
+            newSegment.start -= frameTime * 0.7;
+          }
+        }
+        if (startOrEnd.includes('end')) {
+          await align('end');
+          if (mode === 'keyframeCutFix' && newSegment.end !== fileDuration) {
+            newSegment.end -= frameTime * 0.3;
+          }
+        }
+        if (startOrEnd.includes('start')) {
+          newSegment.start = Math.min(newSegment.start, newSegment.end - frameTime * 0.99); // don't know how ffmpeg interprets cuts between frames
+        } else {
+          newSegment.end = Math.max(newSegment.start + frameTime * 0.99, newSegment.end);
+        }
+
+
         return newSegment;
       });
     } catch (err) {
@@ -528,7 +552,7 @@ function useSegments({ filePath, workingRef, setWorking, setProgress, videoStrea
     } finally {
       setWorking(undefined);
     }
-  }, [videoStream, workingRef, setWorking, modifySelectedSegmentTimes, filePath, handleError]);
+  }, [filePath, videoStream, modifySelectedSegmentTimes, setWorking, workingRef, fileDuration, handleError]);
 
   const updateSegOrder = useCallback((index: number, newOrder: number) => {
     if (newOrder > cutSegments.length - 1 || newOrder < 0) return;

--- a/src/renderer/src/hooks/useSegments.tsx
+++ b/src/renderer/src/hooks/useSegments.tsx
@@ -512,29 +512,33 @@ function useSegments({ filePath, workingRef, setWorking, setProgress, videoStrea
           const time = newSegment[key];
           invariant(filePath != null);
           if (time != null) {
-            let keyframe = await findKeyframeNearTime({ filePath, streamIndex: videoStream.index, time, mode: mode === 'opposing' ? (key === 'start' ? 'before' : 'after') : mode });
-            if (keyframe === undefined) {
-              if (mode !== 'keyframeCutFix') {
-                throw new UserFacingError(i18n.t('Cannot find any keyframe within 60 seconds of frame {{time}}', { time }));
-              }
+            let keyframe = await findKeyframeNearTime({
+              filePath,
+              streamIndex: videoStream.index,
+              time,
+              mode: mode === 'opposing' ? (key === 'start' ? 'before' : 'after') : mode,
+            });
+            if (mode === 'experimental' && keyframe == null) {
               keyframe = fileDuration;
-              console.log(2,time,keyframe);
+            }
+            if (keyframe == null) {
+              throw new UserFacingError(i18n.t('Cannot find any keyframe within 60 seconds of frame {{time}}', { time }));
             }
             newSegment[key] = keyframe;
           }
         }
         if (startOrEnd.includes('start')) {
-          if (mode === 'keyframeCutFix') {
+          if (mode === 'experimental') {
             newSegment.start += frameTime * 0.3;
           }
           await align('start');
-          if (mode === 'keyframeCutFix') {
+          if (mode === 'experimental') {
             newSegment.start -= frameTime * 0.7;
           }
         }
         if (startOrEnd.includes('end')) {
           await align('end');
-          if (mode === 'keyframeCutFix' && newSegment.end !== fileDuration) {
+          if (mode === 'experimental' && newSegment.end !== fileDuration) {
             newSegment.end -= frameTime * 0.3;
           }
         }

--- a/src/renderer/src/hooks/useSegments.tsx
+++ b/src/renderer/src/hooks/useSegments.tsx
@@ -512,7 +512,7 @@ function useSegments({ filePath, workingRef, setWorking, setProgress, videoStrea
           const time = newSegment[key];
           invariant(filePath != null);
           if (time != null) {
-            let keyframe = await findKeyframeNearTime({ filePath, streamIndex: videoStream.index, time, mode });
+            let keyframe = await findKeyframeNearTime({ filePath, streamIndex: videoStream.index, time, mode: mode === 'opposing' ? (key === 'start' ? 'before' : 'after') : mode });
             if (keyframe === undefined) {
               if (mode !== 'keyframeCutFix') {
                 throw new UserFacingError(i18n.t('Cannot find any keyframe within 60 seconds of frame {{time}}', { time }));

--- a/src/renderer/src/hooks/useUserSettingsRoot.ts
+++ b/src/renderer/src/hooks/useUserSettingsRoot.ts
@@ -61,6 +61,8 @@ export default function useUserSettingsRoot() {
   useEffect(() => safeSetConfig({ enableCustomOutDir }), [enableCustomOutDir]);
   const [keyframeCut, setKeyframeCut] = useState(safeGetConfigInitial('keyframeCut'));
   useEffect(() => safeSetConfig({ keyframeCut }), [keyframeCut]);
+  const [autoKeyframeCutFix, setAutoKeyframeCutFix] = useState(safeGetConfigInitial('autoKeyframeCutFix'));
+  useEffect(() => safeSetConfig({ autoKeyframeCutFix }), [autoKeyframeCutFix]);
   const [preserveMetadata, setPreserveMetadata] = useState(safeGetConfigInitial('preserveMetadata'));
   useEffect(() => safeSetConfig({ preserveMetadata }), [preserveMetadata]);
   const [preserveMetadataOnMerge, setPreserveMetadataOnMerge] = useState(safeGetConfigInitial('preserveMetadataOnMerge'));
@@ -249,6 +251,7 @@ export default function useUserSettingsRoot() {
     recentCustomOutDirs,
     enableCustomOutDir,
     keyframeCut,
+    autoKeyframeCutFix,
     preserveMetadata,
     preserveMetadataOnMerge,
     preserveMovData,
@@ -330,6 +333,7 @@ export default function useUserSettingsRoot() {
     setCustomOutDir,
     setRecentCustomOutDirs,
     setKeyframeCut,
+    setAutoKeyframeCutFix,
     setPreserveMetadata,
     setPreserveMetadataOnMerge,
     setPreserveMovData,


### PR DESCRIPTION
aligns the segments to make keyframe cut more consistent

the segment start will be moved to less than one frame before the first keyframe strictly after the start point, ensuring that the cut will be at the last keyframe at or before the start point.

the endpoint can optionally be aligned to a fraction of a frame before the first keyframe at or after the endpoint. this is useful for splitting a video into segments without repeating or missing any frames.

fix #1973 
fix #330

update: while waiting you can download the patch here: https://github.com/ac615223s5/lossless-cut/releases/latest

Edit by @mifi:
If people can test this and report back here with a comment about whether it works or not, that would be great!