### PR TITLE
Fix metadata so that linter is happy and flatpak builds can resume

### DIFF
--- a/no.mifi.losslesscut.appdata.xml
+++ b/no.mifi.losslesscut.appdata.xml
@@ -4,7 +4,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>LosslessCut</name>
-  <summary>Save space by quickly and losslessly trimming video and audio files</summary>
+  <summary>Losslessly trim audio and video</summary>
   <description>
     <p>Simple and ultra fast cross platform tool for lossless trimming/cutting of video and audio files. Great for saving space by rough cutting your large video files taken from a video camera, GoPro, drone, etc. It lets you quickly extract the good parts from your videos and discard many gigabytes of data without doing a slow re-encode and thereby losing quality. It extremely fast because it does an almost direct data copy. It is fueled by the awesome ffmpeg (included) for doing the grunt work. It also features some other lossless operations on videos.</p>
   </description>

--- a/no.mifi.losslesscut.appdata.xml
+++ b/no.mifi.losslesscut.appdata.xml
@@ -12,6 +12,7 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/mifi/lossless-cut/master/main_screenshot.jpg</image>
+      <caption>A screenshot of the main window of LosslessCut</caption>
     </screenshot>
   </screenshots>
   <url type="homepage">https://mifi.no/losslesscut/</url>


### PR DESCRIPTION
Currently the flatpak version of Losslesscut is quite out of date because recent builds have been failing (see: https://github.com/flathub/no.mifi.losslesscut/pull/66)

This MR makes some small metadata fixes to appease the linter so that builds can continue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application summary for clarity: "Losslessly trim audio and video."
	- Added a caption to the screenshot section for better context: "A screenshot of the main window of LosslessCut."
  
These changes enhance user understanding and improve the overall experience with the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->