### PR TITLE
Add developer name to appdata file

### DIFF
--- a/no.mifi.losslesscut.appdata.xml
+++ b/no.mifi.losslesscut.appdata.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>no.mifi.losslesscut</id>
+  <developer id="org.example">
+    <name>Mikael Finstad</name>
+  </developer>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <name>LosslessCut</name>

--- a/no.mifi.losslesscut.appdata.xml
+++ b/no.mifi.losslesscut.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>no.mifi.losslesscut</id>
-  <developer id="org.example">
+  <developer id="no.mifi">
     <name>Mikael Finstad</name>
   </developer>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
Similarly to #2152, this is a simple metadata update to help make the linter in the flatpak repo happy (see: https://github.com/flathub/no.mifi.losslesscut/pull/66 for info)

wasnt exactly sure what to set the id to so i just used no.mifi

Developer name is a required item apparently: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#developer-name

also it seems like `*.appdata.xml` is no longer the current recommended filename for metadata: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#path-and-filename (but that's another issue for another time)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new developer section in the app's metadata, including the developer's name and ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->