### PR TITLE
Allow Toggle Mute At Any Volume

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -220,7 +220,7 @@ function App() {
 
   const previousPlaybackVolume = useRef(playbackVolume);
   const toggleMuted = useCallback(() => {
-    setPlaybackVolume(volume => {
+    setPlaybackVolume((volume) => {
       if (volume === 0) {
         return previousPlaybackVolume.current || 1;
       }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -219,8 +219,7 @@ function App() {
   }, [detectedFileFormat, outFormatLocked, setFileFormat, setOutFormatLocked]);
 
   const toggleMuted = useCallback(() => {
-    if (playbackVolume === 0) setPlaybackVolume(1);
-    if (playbackVolume === 1) setPlaybackVolume(0);
+    setPlaybackVolume(playbackVolume === 0 ? 1 : 0);
   }, [playbackVolume, setPlaybackVolume]);
 
   const toggleShowThumbnails = useCallback(() => setThumbnailsEnabled((v) => !v), []);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -218,9 +218,16 @@ function App() {
     }
   }, [detectedFileFormat, outFormatLocked, setFileFormat, setOutFormatLocked]);
 
+  const previousPlaybackVolume = useRef(playbackVolume);
   const toggleMuted = useCallback(() => {
-    setPlaybackVolume(playbackVolume === 0 ? 1 : 0);
-  }, [playbackVolume, setPlaybackVolume]);
+    setPlaybackVolume(volume => {
+      if (volume === 0) {
+        return previousPlaybackVolume.current || 1;
+      }
+      previousPlaybackVolume.current = volume;
+      return 0;
+    });
+  }, [setPlaybackVolume]);
 
   const toggleShowThumbnails = useCallback(() => setThumbnailsEnabled((v) => !v), []);
 


### PR DESCRIPTION
With the current implementation, you can only toggle mute if the volume is at 0 or 100. Nothing will happen if you try to toggle mute when you're anywhere in between. I thought the keyboard shortcut was broken when trying to use it.

These changes:
- Allow you to toggle mute at any volume
- Remembers your previous volume and toggles back to it


https://github.com/user-attachments/assets/b1fb2d52-1261-4036-9cc2-4cb163395433



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved mute control that restores the previous volume level when unmuting.
- **Refactor**
	- Streamlined volume state management for a more intuitive audio experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->