### PR TITLE
chore: type-safe update checker error logging and remove ts-expect-error

### DIFF
--- a/src/main/updateChecker.ts
+++ b/src/main/updateChecker.ts
@@ -37,8 +37,8 @@ export async function checkNewVersion() {
     if (semver.lt(currentVersion, newestVersion)) return newestVersion;
     return undefined;
   } catch (err) {
-    // @ts-expect-error todo
-    logger.error('Failed to check github version', err.message);
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error('Failed to check github version', message);
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

This PR makes the error logging in [checkNewVersion](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/lossless-cut/src/main/updateChecker.ts:13:0-43:1) type-safe and removes a `@ts-expect-error` while preserving the existing behavior.

## Changes

- **File**: [src/main/updateChecker.ts](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/lossless-cut/src/main/updateChecker.ts:0:0-0:0)
  - Previously the catch block used a `@ts-expect-error` to access `err.message` on a catch variable typed as `unknown`:

    ```ts
    } catch (err) {
      // @ts-expect-error todo
      logger.error('Failed to check github version', err.message);
      return undefined;
    }
    ```

  - Updated it to safely derive a string message from the caught error:

    ```ts
    } catch (err) {
      const message = err instanceof Error ? err.message : String(err);
      logger.error('Failed to check github version', message);
      return undefined;
    }
    ```

## Rationale

- With `useUnknownInCatchVariables` enabled, the catch variable is `unknown`, so directly accessing `err.message` is not type-safe.
- Narrowing `err` with `instanceof Error` and falling back to `String(err)`:
  - Keeps logging behavior intact (always prints a message),
  - Removes the need for `@ts-expect-error`,
  - Makes the code easier to maintain.

## Testing

- Verified by inspection that:
  - Control flow and return values for [checkNewVersion](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/lossless-cut/src/main/updateChecker.ts:13:0-43:1) are unchanged.
  - Logged message remains informative for both `Error` instances and non-Error throwables.