### PR TITLE
Improve export options toggle label hover feedback

### DIFF
--- a/src/renderer/src/components/ExportConfirm.tsx
+++ b/src/renderer/src/components/ExportConfirm.tsx
@@ -293,7 +293,7 @@ function ExportConfirm({
       renderBottom={() => (
         <>
           <ToggleExportConfirm size="1.5em" />
-          <div style={{ fontSize: '.8em', marginLeft: '.4em', marginRight: '.5em', maxWidth: '8.5em', lineHeight: '100%', color: exportConfirmEnabled ? 'var(--gray-12)' : 'var(--gray-11)' }} role="button" onClick={toggleExportConfirmEnabled}>
+          <div style={{ fontSize: '.8em', marginLeft: '.4em', marginRight: '.5em', maxWidth: '8.5em', lineHeight: '100%', color: exportConfirmEnabled ? 'var(--gray-12)' : 'var(--gray-11)', cursor: 'pointer' }} role="button" onClick={toggleExportConfirmEnabled}>
             {t('Show this page before exporting?')}
           </div>
           {notices.totalNum > 0 && (


### PR DESCRIPTION
This PR makes a small UX improvement in the Export options sheet.

In the bottom bar, the “Show this page before exporting?” text already acts as a button:
- It has `role="button"`.
- It toggles the `exportConfirmEnabled` setting on click.

However, it previously did not show a pointer cursor on hover, making it look like plain text.

Change:
- Add `cursor: 'pointer'` to the label’s inline style so that the mouse cursor reflects that it is clickable.

No behavior, text, or i18n keys were changed – only visual hover feedback for an existing control.
File touched:
- [src/renderer/src/components/ExportConfirm.tsx](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/lossless-cut/src/renderer/src/components/ExportConfirm.tsx:0:0-0:0)