### PR TITLE
Fix exact duration regex to require a literal dot separator

### DIFF
--- a/src/renderer/src/util/duration.ts
+++ b/src/renderer/src/util/duration.ts
@@ -43,7 +43,7 @@ export function formatDuration({ seconds: totalSecondsIn, fileNameFriendly, show
   return `${sign}${hoursPart}${minutesPadded}${delim}${secondsPadded}${fraction}`;
 }
 
-const exactDurationRegex = /^-?\d{2}:\d{2}:\d{2}.\d{3}$/;
+const exactDurationRegex = /^-?\d{2}:\d{2}:\d{2}\.\d{3}$/;
 const durationRegex = /^(-?)(?:(?:(\d+):)?(\d{1,2}):)?(\d+(?:[,.]\d+)?)$/;
 
 // todo adapt also to frame counts and frame fractions?


### PR DESCRIPTION
## Summary
Fixes [isExactDurationMatch](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/Prisca/lossless-cut/src/renderer/src/util/duration.ts:48:0-49:82) so it only matches durations with a literal dot (`.`) before milliseconds.

Previously, the regex used an unescaped `.` which matched any character, so invalid inputs like `00:00:00x123` could be treated as “exact duration”.

## Changes
- Update `exactDurationRegex` in [src/renderer/src/util/duration.ts](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/App/Prisca/lossless-cut/src/renderer/src/util/duration.ts:0:0-0:0) to escape the dot: `\.`

## Impact
- Prevents false-positive “exact duration” matches in time input handling (e.g. BottomBar cut time input).
- No behavior change for valid inputs like `00:00:00.123`.

