### PR TITLE
Fix JPEG quality mapping for frame capture (-q:v)

### DIFF
--- a/src/main/ffmpeg.ts
+++ b/src/main/ffmpeg.ts
@@ -448,7 +448,8 @@ function getFfmpegJpegQuality(quality: number) {
   // Normal range for JPEG is 2-31 with 31 being the worst quality.
   const qMin = 2;
   const qMax = 31;
-  return Math.min(Math.max(qMin, quality, Math.round((1 - quality) * (qMax - qMin) + qMin)), qMax);
+  const normalizedQuality = Math.max(0, Math.min(1, quality));
+  return Math.min(Math.max(qMin, Math.round((1 - normalizedQuality) * (qMax - qMin) + qMin)), qMax);
 }
 
 function getQualityOpts({ captureFormat, quality }: { captureFormat: CaptureFormat, quality: number }) {


### PR DESCRIPTION
## Summary
Fixes the mapping from the UI quality value (0–1) to ffmpeg’s JPEG `-q:v` scale (2–31, where 2 is best quality).

Previously, `getFfmpegJpegQuality` mixed the raw `quality` value into the clamping logic, which effectively forced the result to `2` in normal cases, making the quality setting mostly ignored.

## Changes
- Clamp input quality to `[0, 1]`
- Map to ffmpeg qscale correctly: `q = round((1 - quality) * (qMax - qMin) + qMin)` and clamp to `[2, 31]`
- Affects both single-frame capture and multi-frame extraction paths (shared helper).

## Impact
- JPEG quality setting now actually affects output size/quality as intended.
