### PR TITLE
Set snap base to core22 for newer GPU support

### DIFF
--- a/package.json
+++ b/package.json
@@ -481,6 +481,7 @@
       ]
     },
     "snap": {
+      "base": "core22",
       "plugs": [
         "default",
         "removable-media"


### PR DESCRIPTION
## Summary

- Set snap `base` to `core22` in electron-builder config
- Fixes segfault on launch caused by the `core20` default bundling Mesa drivers too old for newer GPUs (e.g. Intel Arrow Lake `8086:64a0`)
- `core22` pulls in the Ubuntu 22.04 GNOME platform snap with updated Mesa, resolving the `kms_swrast`/`swrast` driver loading failures
- The snap base is self-contained, so this won't break users on older Ubuntu — it only requires snapd 2.55+, which has been available on 20.04 for years

Fixes #2614