### PR TITLE
Fix fractional frame cut time input

### DIFF
--- a/src/renderer/src/BottomBar.tsx
+++ b/src/renderer/src/BottomBar.tsx
@@ -22,7 +22,7 @@ import { withBlur, mirrorTransform } from './util';
 import getSwal from './swal';
 import { getSegColor as getSegColorRaw } from './util/colors';
 import { useSegColors } from './contexts';
-import { isExactDurationMatch } from './util/duration';
+import { isExactTimecodeMatch } from './util/duration';
 import useUserSettings from './hooks/useUserSettings';
 import useActionTitle from './hooks/useActionTitle';
 import { askForPlaybackRate, checkAppPath } from './dialogs';
@@ -169,7 +169,7 @@ const CutTimeInput = memo(({ disabled, darkMode, cutTime, setCutTime, startTimeO
 
   const handleCutTimeInput = useCallback((text: string) => {
     try {
-      if (isExactDurationMatch(text) || isEmptyEndTime(text)) {
+      if (isExactTimecodeMatch(text, parseTimecode, formatTimecode) || isEmptyEndTime(text)) {
         parseAndSetCutTime(text);
         return;
       }
@@ -180,7 +180,7 @@ const CutTimeInput = memo(({ disabled, darkMode, cutTime, setCutTime, startTimeO
 
     // else or if error, just set manual value, to make sure it doesn't jump to end https://github.com/mifi/lossless-cut/issues/988#issuecomment-3475870072
     setCutTimeManual(text);
-  }, [isEmptyEndTime, parseAndSetCutTime]);
+  }, [formatTimecode, isEmptyEndTime, parseAndSetCutTime, parseTimecode]);
 
   const handleInputBlur = useCallback(() => {
     setCutTimeManual(undefined);

--- a/src/renderer/src/util/duration.test.ts
+++ b/src/renderer/src/util/duration.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from 'vitest';
 
-import { formatDuration, parseDuration } from './duration';
+import { formatDuration, isExactTimecodeMatch, parseDuration } from './duration';
 
 it('should format duration properly', () => {
   expect(formatDuration({ seconds: 1.5, fps: 30 })).toBe('00:00:01.15');
@@ -52,6 +52,30 @@ it('should format and parse duration with correct rounding', () => {
   // https://github.com/mifi/lossless-cut/issues/254#issuecomment-2781652373
   expect(formatDuration({ seconds: parseDuration('71.2') })).toBe('00:01:11.200');
   expect(formatDuration({ seconds: parseDuration('1000') })).toBe('00:16:40.000');
+});
+
+it('should detect complete timecodes for the active format', () => {
+  const decimalFormat = ({ seconds }: { seconds: number }) => formatDuration({ seconds });
+  const frameFormat = ({ seconds }: { seconds: number }) => formatDuration({ seconds, fps: 30 });
+
+  expect(isExactTimecodeMatch('00:00:01.500', parseDuration, decimalFormat)).toBe(true);
+  expect(isExactTimecodeMatch('00:00:01.50', parseDuration, decimalFormat)).toBe(false);
+
+  expect(isExactTimecodeMatch('00:00:01.15', (value) => parseDuration(value, 30), frameFormat)).toBe(true);
+  expect(isExactTimecodeMatch('00:00:01.1', (value) => parseDuration(value, 30), frameFormat)).toBe(false);
+
+  const fractionalFps = 23.976;
+  expect(isExactTimecodeMatch(
+    '00:00:32.15',
+    (value) => parseDuration(value, fractionalFps),
+    ({ seconds }) => formatDuration({ seconds, fps: fractionalFps }),
+  )).toBe(true);
+
+  expect(isExactTimecodeMatch('1.500', parseFloat, ({ seconds }) => seconds.toFixed(3))).toBe(true);
+  expect(isExactTimecodeMatch('1.50', parseFloat, ({ seconds }) => seconds.toFixed(3))).toBe(false);
+
+  expect(isExactTimecodeMatch('45', (value) => parseInt(value, 10), ({ seconds }) => String(seconds))).toBe(true);
+  expect(isExactTimecodeMatch('invalid', parseFloat, ({ seconds }) => seconds.toFixed(3))).toBe(false);
 });
 
 // https://github.com/mifi/lossless-cut/issues/1603

--- a/src/renderer/src/util/duration.ts
+++ b/src/renderer/src/util/duration.ts
@@ -1,5 +1,7 @@
 import padStart from 'lodash/padStart';
 
+import type { FormatTimecode, ParseTimecode } from '../types';
+
 export function formatDuration({ seconds: totalSecondsIn, fileNameFriendly, showFraction = true, shorten = false, fps }: {
   seconds?: number | undefined,
   fileNameFriendly?: boolean | undefined,
@@ -43,11 +45,12 @@ export function formatDuration({ seconds: totalSecondsIn, fileNameFriendly, show
   return `${sign}${hoursPart}${minutesPadded}${delim}${secondsPadded}${fraction}`;
 }
 
-const exactDurationRegex = /^-?\d{2}:\d{2}:\d{2}\.\d{3}$/;
 const durationRegex = /^(-?)(?:(?:(\d+):)?(\d{1,2}):)?(\d+(?:[,.]\d+)?)$/;
 
-// todo adapt also to frame counts and frame fractions?
-export const isExactDurationMatch = (str: string) => exactDurationRegex.test(str);
+export const isExactTimecodeMatch = (str: string, parseTimecode: ParseTimecode, formatTimecode: FormatTimecode) => {
+  const seconds = parseTimecode(str);
+  return seconds != null && Number.isFinite(seconds) && formatTimecode({ seconds }) === str;
+};
 
 // See also parseYoutube
 export function parseDuration(str: string, fps?: number) {


### PR DESCRIPTION
## Summary

- detect complete cut time input using the active parser and formatter instead of a millisecond-only regex
- allow fractional-frame IN/OUT values to commit while preserving partial and invalid edit state
- cover millisecond, frame-fraction, total-seconds, and frame-count formats

## Testing

- dependency-free source smoke check
- `git diff --check`
- focused Vitest regression cases added; full dependency-based checks deferred to CI because local Yarn cache writes were blocked

Fixes #2969

Implementation and tests were prepared with AI assistance and reviewed against the current input lifecycle.