### PR TITLE
Sanitize generated output basenames on Windows

### DIFF
--- a/src/renderer/src/util/outputNameTemplate.test.ts
+++ b/src/renderer/src/util/outputNameTemplate.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+vi.mock('../worker/eval', () => ({
+  default: async (expression: string, context: Record<string, unknown>) => {
+    // eslint-disable-next-line no-template-curly-in-string
+    if (expression !== '`${SEG_LABEL.replaceAll(\'_\', \':\')}${EXT}`') throw new Error(`Unexpected expression: ${expression}`);
+    return `${String(context.SEG_LABEL).replaceAll('_', ':')}${String(context.EXT)}`;
+  },
+}));
+
+type WindowWithRequire = Window & {
+  require: (specifier: string) => unknown;
+  process: {
+    mas?: boolean;
+    windowsStore?: boolean;
+  };
+};
+
+const originalWindow = globalThis.window;
+
+function createWindowMock(): WindowWithRequire {
+  const remote = {
+    app: {
+      getVersion: () => '0.0.0-test',
+      getAppPath: () => '/app',
+    },
+    require: (specifier: string) => {
+      if (specifier === './index.js') return { isWindows: true, isMac: false };
+      throw new Error(`Unexpected remote require: ${specifier}`);
+    },
+  };
+
+  return {
+    process: { mas: false, windowsStore: false },
+    require: (specifier: string) => {
+      if (specifier === 'node:path') return require('node:path');
+      if (specifier === 'node:fs/promises') return require('node:fs/promises');
+      if (specifier === '@electron/remote') return remote;
+      if (specifier === 'electron') return { ipcRenderer: { invoke: vi.fn() } };
+      throw new Error(`Unexpected window.require: ${specifier}`);
+    },
+  } as WindowWithRequire;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubGlobal('window', createWindowMock());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (originalWindow == null) delete (globalThis as { window?: Window }).window;
+  else globalThis.window = originalWindow;
+});
+
+describe('generateCutFileNames', () => {
+  it('sanitizes the final output basename when template logic reintroduces invalid Windows characters', async () => {
+    const { generateCutFileNames } = await import('./outputNameTemplate');
+
+    const { fileNames, problems } = await generateCutFileNames({
+      fileDuration: 120,
+      segmentsToExport: [{
+        start: 10,
+        end: 20,
+        name: '00:10:05.605 2',
+        originalIndex: 0,
+      }],
+      // eslint-disable-next-line no-template-curly-in-string
+      template: '${SEG_LABEL.replaceAll(\'_\', \':\')}${EXT}',
+      formatTimecode: ({ seconds }) => seconds.toFixed(3),
+      isCustomFormatSelected: true,
+      fileFormat: 'matroska',
+      sourceFile: { path: String.raw`C:\input\clip.mkv` },
+      outputDir: String.raw`C:\output`,
+      safeOutputFileName: true,
+      maxLabelLength: 100,
+      outputFileNameMinZeroPadding: 1,
+      exportCount: 0,
+      currentFileExportCount: 0,
+    });
+
+    expect(problems.error).toBeUndefined();
+    expect(fileNames).toEqual(['00_10_05.605 2.mkv']);
+  });
+});

--- a/src/renderer/src/util/outputNameTemplate.ts
+++ b/src/renderer/src/util/outputNameTemplate.ts
@@ -234,6 +234,21 @@ function maybeTruncatePath(fileName: string, truncate: boolean) {
   ].join(pathSep);
 }
 
+function sanitizeOutputBasename(fileName: string, sanitizeName: (name: string) => string, safeOutputFileName: boolean) {
+  if (!safeOutputFileName) return fileName;
+
+  const pathSegs = fileName.split(pathSep);
+  if (pathSegs.length === 0) return fileName;
+
+  const [lastSeg] = pathSegs.slice(-1);
+  if (lastSeg == null) return fileName;
+
+  const { name, ext } = parsePath(lastSeg);
+  const sanitizedLastSeg = `${sanitizeName(name)}${filenamify(ext)}`;
+
+  return [...pathSegs.slice(0, -1), sanitizedLastSeg].join(pathSep);
+}
+
 async function generateWithFallback({ generate, desiredTemplate, defaultTemplate, safeOutputFileName, filePath, outputDir, maxLabelLength }: {
   generate: (a: {
     template: string,
@@ -336,7 +351,7 @@ export async function generateCutFileNames({ fileDuration, segmentsToExport: seg
           currentFileExportCount,
         });
 
-        return maybeTruncatePath(segFileName, safeOutputFileName2);
+        return maybeTruncatePath(sanitizeOutputBasename(segFileName, sanitizeName, safeOutputFileName2), safeOutputFileName2);
       }, { concurrency: 5 });
     },
     desiredTemplate,
@@ -377,7 +392,7 @@ export async function generateCutMergedFileNames({ template: desiredTemplate, is
         segLabels: segLabels.map((label) => sanitizeName(label)),
       });
 
-      return [maybeTruncatePath(fileName, safeOutputFileName2)];
+      return [maybeTruncatePath(sanitizeOutputBasename(fileName, sanitizeName, safeOutputFileName2), safeOutputFileName2)];
     },
     desiredTemplate,
     defaultTemplate: defaultCutMergedFileTemplate,
@@ -415,7 +430,7 @@ export async function generateMergedFileNames({ template: desiredTemplate, isCus
         segLabels: sourceFiles.map((file) => sanitizeName(basename(file.path))),
       });
 
-      return [maybeTruncatePath(fileName, safeOutputFileName2)];
+      return [maybeTruncatePath(sanitizeOutputBasename(fileName, sanitizeName, safeOutputFileName2), safeOutputFileName2)];
     },
     desiredTemplate,
     defaultTemplate: defaultCutMergedFileTemplate,


### PR DESCRIPTION
## Summary
- sanitize the final generated output basename when safe output file names are enabled
- prevent template logic or imported labels from reintroducing Windows-invalid characters like `:`
- add a regression test covering the Windows chapter-label case reported in #2986

## Testing
- corepack yarn eslint src/renderer/src/util/outputNameTemplate.ts src/renderer/src/util/outputNameTemplate.test.ts
- corepack yarn vitest run src/renderer/src/util/outputNameTemplate.test.ts src/renderer/src/util/duration.test.ts