### PR TITLE
Add undo/redo to the export file name template editor

### DIFF
--- a/src/renderer/src/components/FileNameTemplateEditor.tsx
+++ b/src/renderer/src/components/FileNameTemplateEditor.tsx
@@ -1,10 +1,10 @@
-import type { ChangeEventHandler } from 'react';
-import { memo, useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import type { ChangeEventHandler, KeyboardEventHandler } from 'react';
+import { memo, useState, useEffect, useCallback, useLayoutEffect, useReducer, useRef, useMemo } from 'react';
 import { useDebounce } from 'use-debounce';
 import { useTranslation } from 'react-i18next';
 import { IoIosHelpCircle } from 'react-icons/io';
 import { motion, AnimatePresence } from 'motion/react';
-import { FaCaretUp, FaEdit, FaExclamationTriangle, FaEye, FaFile, FaUndo } from 'react-icons/fa';
+import { FaCaretUp, FaEdit, FaExclamationTriangle, FaEye, FaFile, FaRedoAlt, FaUndo, FaUndoAlt } from 'react-icons/fa';
 
 import HighlightedText from './HighlightedText';
 import type { GenerateOutFileNames, GeneratedOutFileNames } from '../util/outputNameTemplate';
@@ -18,6 +18,7 @@ import * as Dialog from './Dialog';
 import { dangerColor, warningColor } from '../colors';
 import { exportedFileNameTemplateHelpUrl } from '../../../common/constants';
 import mainApi from '../mainApi';
+import { canRedo, canUndo, createTextHistory, getTextHistoryValue, textHistoryReducer } from '../util/textHistory';
 
 
 const formatVariable = (variable: string) => `\${${variable}}`;
@@ -43,6 +44,7 @@ function FileNameTemplateEditor(opts: {
 
   const [text, setText] = useState(templateIn);
   const [debouncedText] = useDebounce(text, 500);
+  const [history, dispatchHistory] = useReducer(textHistoryReducer, templateIn, createTextHistory);
   const [generated, setGenerated] = useState<GeneratedOutFileNames>();
 
   const isSimpleMergeFilesMode = simpleMode && mode === 'merge-files';
@@ -63,6 +65,8 @@ function FileNameTemplateEditor(opts: {
   }, [templateIn]);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  // caret position to restore after we replace the whole value (undo/redo), because the browser would put it at the end
+  const caretRef = useRef<number>(undefined);
 
   const { t } = useTranslation();
 
@@ -120,20 +124,81 @@ function FileNameTemplateEditor(opts: {
     setTemplate(debouncedText);
   }, [debouncedText, setTemplate]);
 
+  // record into the undo history only once typing settles, so a burst of keystrokes becomes a single undo step.
+  // it's a no-op when the value is already the current entry, e.g. when the debounce catches up after an undo
+  useEffect(() => {
+    dispatchHistory({ type: 'set', value: debouncedText });
+  }, [debouncedText]);
+
   useEffect(() => {
     if (open) inputRef.current?.focus();
   }, [open]);
 
+  useLayoutEffect(() => {
+    if (caretRef.current == null) return;
+    inputRef.current?.setSelectionRange(caretRef.current, caretRef.current);
+    caretRef.current = undefined;
+  }, [text]);
+
+  // typing that the debounce hasn't recorded yet still needs to be undoable
+  const hasPendingEdit = text !== getTextHistoryValue(history);
+  const undoEnabled = hasPendingEdit || canUndo(history);
+  const redoEnabled = !hasPendingEdit && canRedo(history);
+
+  const applyValue = useCallback((value: string) => {
+    caretRef.current = value.length;
+    setText(value);
+  }, []);
+
+  // records a discrete edit (variable insertion, reset) as its own undo step right away,
+  // first committing any typing that the debounce hasn't recorded yet
+  const recordEdit = useCallback((value: string) => {
+    if (text !== getTextHistoryValue(history)) dispatchHistory({ type: 'set', value: text });
+    dispatchHistory({ type: 'set', value });
+  }, [history, text]);
+
+  const undo = useCallback(() => {
+    if (hasPendingEdit) {
+      dispatchHistory({ type: 'set', value: text });
+      dispatchHistory({ type: 'undo' });
+      applyValue(getTextHistoryValue(history));
+      return;
+    }
+    if (!canUndo(history)) return;
+    dispatchHistory({ type: 'undo' });
+    applyValue(history.stack[history.index - 1]!);
+  }, [applyValue, hasPendingEdit, history, text]);
+
+  const redo = useCallback(() => {
+    if (!redoEnabled) return;
+    dispatchHistory({ type: 'redo' });
+    applyValue(history.stack[history.index + 1]!);
+  }, [applyValue, history, redoEnabled]);
+
   const reset = useCallback(() => {
     setTemplate(defaultTemplate);
-    setText(defaultTemplate);
-  }, [defaultTemplate, setTemplate]);
+    recordEdit(defaultTemplate);
+    applyValue(defaultTemplate);
+  }, [applyValue, defaultTemplate, recordEdit, setTemplate]);
 
   const handleSampleClick = useCallback(() => {
     setOpen((v) => !v);
   }, []);
 
   const onTextChange = useCallback<ChangeEventHandler<HTMLInputElement>>((e) => setText(e.target.value), []);
+
+  // the browser's own undo can't restore programmatic edits (variable insertion, reset), so handle it ourselves
+  const onTextKeyDown = useCallback<KeyboardEventHandler<HTMLInputElement>>((e) => {
+    if (e.altKey || !(e.ctrlKey || e.metaKey)) return;
+    const key = e.key.toLowerCase();
+    if (key === 'z' && !e.shiftKey) {
+      e.preventDefault();
+      undo();
+    } else if ((key === 'z' && e.shiftKey) || key === 'y') {
+      e.preventDefault();
+      redo();
+    }
+  }, [redo, undo]);
 
   const onVariableClick = useCallback((variable: string) => {
     const input = inputRef.current;
@@ -144,8 +209,9 @@ function FileNameTemplateEditor(opts: {
     const toInsert = variable === segTagsExample ? `${segTagsExample} ?? ''` : variable;
 
     const newValue = `${text.slice(0, startPos)}${`${formatVariable(toInsert)}${text.slice(endPos)}`}`;
+    recordEdit(newValue);
     setText(newValue);
-  }, [text]);
+  }, [recordEdit, text]);
 
   function formatCurrentSegFileOrFirst(names: string[]) {
     if (mode === 'separate') {
@@ -201,7 +267,7 @@ function FileNameTemplateEditor(opts: {
               )}
 
               <div style={{ display: 'flex', alignItems: 'center', marginBottom: '.2em', gap: '.5em' }}>
-                <TextInput ref={inputRef} onChange={onTextChange} value={text} autoComplete="off" autoCapitalize="off" autoCorrect="off" style={{ padding: '.3em' }} />
+                <TextInput ref={inputRef} onChange={onTextChange} onKeyDown={onTextKeyDown} value={text} autoComplete="off" autoCapitalize="off" autoCorrect="off" style={{ padding: '.3em' }} />
 
                 {generated != null && generated.fileNames.length > 1 && (
                   <Dialog.Root>
@@ -225,7 +291,12 @@ function FileNameTemplateEditor(opts: {
                 )}
 
                 {!isSimpleMergeFilesMode && (
-                  <Button onClick={reset} style={{ marginLeft: '.3em', padding: '.3em' }}><FaUndo style={{ fontSize: '.8em', color: dangerColor, marginRight: '.5em' }} />{t('Reset')}</Button>
+                  <>
+                    <Button onClick={undo} disabled={!undoEnabled} title={t('Undo')} style={{ marginLeft: '.3em', padding: '.3em' }}><FaUndoAlt style={{ fontSize: '.8em' }} /></Button>
+                    <Button onClick={redo} disabled={!redoEnabled} title={t('Redo')} style={{ padding: '.3em' }}><FaRedoAlt style={{ fontSize: '.8em' }} /></Button>
+
+                    <Button onClick={reset} style={{ marginLeft: '.3em', padding: '.3em' }}><FaUndo style={{ fontSize: '.8em', color: dangerColor, marginRight: '.5em' }} />{t('Reset')}</Button>
+                  </>
                 )}
               </div>
 

--- a/src/renderer/src/util/textHistory.test.ts
+++ b/src/renderer/src/util/textHistory.test.ts
@@ -1,0 +1,70 @@
+import { it, expect } from 'vitest';
+
+import type { TextHistory } from './textHistory';
+import { canRedo, canUndo, createTextHistory, getTextHistoryValue, maxTextHistoryLength, textHistoryReducer } from './textHistory';
+
+const set = (history: TextHistory, value: string) => textHistoryReducer(history, { type: 'set', value });
+const undo = (history: TextHistory) => textHistoryReducer(history, { type: 'undo' });
+const redo = (history: TextHistory) => textHistoryReducer(history, { type: 'redo' });
+
+it('should start with a single entry that cannot be undone or redone', () => {
+  const history = createTextHistory('a');
+  expect(getTextHistoryValue(history)).toBe('a');
+  expect(canUndo(history)).toBe(false);
+  expect(canRedo(history)).toBe(false);
+});
+
+it('should undo and redo edits', () => {
+  let history = set(set(createTextHistory('a'), 'ab'), 'abc');
+  expect(getTextHistoryValue(history)).toBe('abc');
+
+  history = undo(history);
+  expect(getTextHistoryValue(history)).toBe('ab');
+  expect(canUndo(history)).toBe(true);
+  expect(canRedo(history)).toBe(true);
+
+  history = undo(history);
+  expect(getTextHistoryValue(history)).toBe('a');
+  expect(canUndo(history)).toBe(false);
+
+  history = redo(redo(history));
+  expect(getTextHistoryValue(history)).toBe('abc');
+  expect(canRedo(history)).toBe(false);
+});
+
+it('should ignore no-op sets, so a debounced value catching up after an undo does nothing', () => {
+  const history = set(createTextHistory('a'), 'ab');
+  const undone = undo(history);
+  // the debounced value arrives after the undo already restored 'a'
+  expect(set(undone, 'a')).toBe(undone);
+  expect(getTextHistoryValue(redo(set(undone, 'a')))).toBe('ab');
+});
+
+it('should not undo or redo past the ends', () => {
+  const history = createTextHistory('a');
+  expect(undo(history)).toBe(history);
+  expect(redo(history)).toBe(history);
+});
+
+it('should discard redo entries when editing after an undo', () => {
+  const history = undo(set(set(createTextHistory('a'), 'ab'), 'abc'));
+  expect(canRedo(history)).toBe(true);
+
+  const edited = set(history, 'abX');
+  expect(canRedo(edited)).toBe(false);
+  expect(getTextHistoryValue(edited)).toBe('abX');
+  expect(getTextHistoryValue(undo(edited))).toBe('ab');
+});
+
+it('should drop the oldest entries once the maximum length is exceeded', () => {
+  let history = createTextHistory('0');
+  for (let i = 1; i < maxTextHistoryLength + 10; i += 1) history = set(history, String(i));
+
+  expect(history.stack).toHaveLength(maxTextHistoryLength);
+  expect(getTextHistoryValue(history)).toBe(String(maxTextHistoryLength + 9));
+  expect(history.stack[0]).toBe('10');
+
+  // undoing all the way back lands on the oldest retained entry, not on '0'
+  while (canUndo(history)) history = undo(history);
+  expect(getTextHistoryValue(history)).toBe('10');
+});

--- a/src/renderer/src/util/textHistory.ts
+++ b/src/renderer/src/util/textHistory.ts
@@ -1,0 +1,45 @@
+// Undo/redo history for a single text value, e.g. the export file name template.
+// Kept as a pure reducer so it can be unit tested without rendering a component.
+
+export interface TextHistory {
+  readonly stack: readonly string[],
+  readonly index: number,
+}
+
+export type TextHistoryAction =
+  | { type: 'set', value: string }
+  | { type: 'undo' }
+  | { type: 'redo' };
+
+// don't grow unbounded if the user keeps editing for a long time
+export const maxTextHistoryLength = 100;
+
+export const createTextHistory = (value: string): TextHistory => ({ stack: [value], index: 0 });
+
+export const getTextHistoryValue = (history: TextHistory) => history.stack[history.index]!;
+
+export const canUndo = (history: TextHistory) => history.index > 0;
+
+export const canRedo = (history: TextHistory) => history.index < history.stack.length - 1;
+
+export function textHistoryReducer(history: TextHistory, action: TextHistoryAction): TextHistory {
+  switch (action.type) {
+    case 'set': {
+      // ignore no-op changes, e.g. when the debounced value catches up after an undo
+      if (action.value === getTextHistoryValue(history)) return history;
+      // a new edit discards anything that could have been redone
+      const stack = [...history.stack.slice(0, history.index + 1), action.value];
+      const overflow = Math.max(0, stack.length - maxTextHistoryLength);
+      return { stack: stack.slice(overflow), index: stack.length - overflow - 1 };
+    }
+    case 'undo': {
+      return canUndo(history) ? { ...history, index: history.index - 1 } : history;
+    }
+    case 'redo': {
+      return canRedo(history) ? { ...history, index: history.index + 1 } : history;
+    }
+    default: {
+      return history;
+    }
+  }
+}


### PR DESCRIPTION
Closes #3017

The export file name template input is a controlled React input, so the browser's native undo cannot restore edits made programmatically — inserting a variable by clicking it, or pressing **Reset**. Those edits were effectively permanent: recovering a template you'd spent time on meant retyping it.

This adds a small undo history scoped to that editor.

- Typing is coalesced by the **existing** 500 ms debounce, so a burst of keystrokes is one undo step rather than one per character. Variable insertion and Reset are recorded immediately, so they're undoable even within the debounce window.
- Undo/Redo buttons sit next to Reset; <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Z</kbd>, <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> and <kbd>Ctrl</kbd>+<kbd>Y</kbd> work while the input is focused. The handler calls `preventDefault` so the browser's own (ineffective here) undo doesn't also fire.
- The history is a pure reducer in `src/renderer/src/util/textHistory.ts`, so it's unit tested without rendering — 6 tests added.
- Nothing changes in simple merge-files mode, where `Reset` is already hidden.

A couple of design notes for review:

- The `set` action is a no-op when the value already equals the current entry. That's what makes the debounced value catching up *after* an undo harmless — no guard flag and no timing coupling between the debounce and the history.
- Typing that the debounce hasn't recorded yet is committed as its own step before an undo runs, so pressing undo mid-burst doesn't skip past what you just typed.
- History is capped at 100 entries.

`yarn tsc`, `yarn lint`, `yarn test run` (91/91) and `electron-vite build` all pass. `yarn scan-i18n` adds no new keys — `Undo` and `Redo` are already translated. Also verified by hand in `yarn dev` on Windows: burst typing undone as one step, chip insertion undone, Reset undone, and redo working from both the buttons and the keyboard.
