### PR TITLE
Report missing source file in more export paths, and stop passing muxer flags to the wrong muxer

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1706,6 +1706,8 @@ function App() {
 
       if (err instanceof RefuseOverwriteError) {
         showRefuseToOverwrite();
+      } else if (err instanceof UserFacingError) {
+        errorToast(err.message);
       } else {
         errorToast(i18n.t('Failed to extract all streams'));
         console.error('Failed to extract all streams', err);
@@ -2248,6 +2250,8 @@ function App() {
 
       if (err instanceof RefuseOverwriteError) {
         showRefuseToOverwrite();
+      } else if (err instanceof UserFacingError) {
+        errorToast(err.message);
       } else {
         errorToast(i18n.t('Failed to extract track'));
         console.error('Failed to extract track', err);

--- a/src/renderer/src/hooks/useFfmpegOperations.ts
+++ b/src/renderer/src/hooks/useFfmpegOperations.ts
@@ -41,7 +41,19 @@ async function writeChaptersFfmetadata(outDir: string, chapters: Chapter[] | und
   return path;
 }
 
-function getMovFlags({ preserveMovData, movFastStart }: { preserveMovData: boolean, movFastStart: boolean }) {
+// Muxers implemented by ffmpeg's movenc.c, i.e. the ones that accept `-movflags`.
+// Note: deliberately not util/streams.ts `isMov`, which is a narrower, UI oriented list.
+const movencFormats = new Set(['3g2', '3gp', 'f4v', 'ipod', 'ismv', 'mov', 'mp4', 'psp']);
+
+// Muxers implemented by ffmpeg's matroskaenc.c, i.e. the ones that accept `-default_mode`.
+const matroskaencFormats = new Set(['matroska', 'webm']);
+
+// ffmpeg tolerates private options belonging to a different muxer, but they add noise to the command line
+// that we log, show in "Last commands" and include in error reports - which makes troubleshooting harder.
+// If the output format is unknown, ffmpeg infers the muxer from the file extension, so keep the flags to be safe.
+function getMovFlags({ outFormat, preserveMovData, movFastStart }: { outFormat: string | undefined, preserveMovData: boolean, movFastStart: boolean }) {
+  if (outFormat != null && !movencFormats.has(outFormat)) return [];
+
   const flags: string[] = [];
 
   // https://video.stackexchange.com/a/26084/29486
@@ -55,7 +67,10 @@ function getMovFlags({ preserveMovData, movFastStart }: { preserveMovData: boole
   return flags.flatMap((flag) => ['-movflags', flag]);
 }
 
-function getMatroskaFlags() {
+// same as getMovFlags, but for the matroska muxer's private options
+function getMatroskaFlags(outFormat: string | undefined) {
+  if (outFormat != null && !matroskaencFormats.has(outFormat)) return [];
+
   return [
     '-default_mode', 'infer_no_subs',
     // because it makes sense to not force subtitles disposition to "default" if they were not default in the input file
@@ -201,8 +216,8 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
 
         ...(chaptersInputIndex != null ? ['-map_chapters', String(chaptersInputIndex)] : []),
 
-        ...getMovFlags({ preserveMovData, movFastStart }),
-        ...getMatroskaFlags(),
+        ...getMovFlags({ outFormat, preserveMovData, movFastStart }),
+        ...getMatroskaFlags(outFormat),
 
         // See https://github.com/mifi/lossless-cut/issues/170
         '-ignore_unknown',
@@ -454,8 +469,8 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
 
       ...(shortestFlag ? ['-shortest'] : []),
 
-      ...getMovFlags({ preserveMovData, movFastStart }),
-      ...getMatroskaFlags(),
+      ...getMovFlags({ outFormat, preserveMovData, movFastStart }),
+      ...getMatroskaFlags(outFormat),
 
       ...customFileMetadataArgs,
 
@@ -1081,6 +1096,7 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
     customOutDir: string | undefined, streams: FFprobeStream[],
   }) => {
     invariant(filePath != null);
+    await assertFileExists(filePath);
 
     const attachmentStreams = streams.filter((s) => s.codec_type === 'attachment');
     const nonAttachmentStreams = streams.filter((s) => s.codec_type !== 'attachment');

--- a/src/renderer/src/hooks/useFrameCapture.ts
+++ b/src/renderer/src/hooks/useFrameCapture.ts
@@ -2,7 +2,7 @@ import { dataUriToBuffer } from 'data-uri-to-buffer';
 import pMap from 'p-map';
 import { useCallback } from 'react';
 
-import { getSuffixedOutPath, getOutDir, transferTimestamps, getSuffixedFileName, getOutPath, escapeRegExp, fsOperationWithRetry } from '../util';
+import { getSuffixedOutPath, getOutDir, transferTimestamps, getSuffixedFileName, getOutPath, escapeRegExp, fsOperationWithRetry, assertFileExists } from '../util';
 import { getNumDigits, isDurationValid } from '../segments';
 
 import * as ffmpeg from '../ffmpeg';
@@ -45,6 +45,9 @@ export default ({ appendFfmpegCommandLog, formatTimecode, treatInputFileModified
     onProgress: (a: number) => void,
     outputTimestamps: boolean,
   }) => {
+    // fail fast with a helpful message if the source file has been moved/deleted since it was opened
+    await assertFileExists(filePath);
+
     const getSuffix = (prefix: string) => `${prefix}.${captureFormat}`;
 
     if (!outputTimestamps) {
@@ -98,6 +101,8 @@ export default ({ appendFfmpegCommandLog, formatTimecode, treatInputFileModified
     captureFormat: CaptureFormat,
     quality: number,
   }) => {
+    await assertFileExists(filePath);
+
     const timecode = formatTimecode({ seconds: time, fileNameFriendly: true });
     const nameSuffix = `${timecode}.${captureFormat}`;
     const outPath = getSuffixedOutPath({ customOutDir, filePath, nameSuffix });


### PR DESCRIPTION
Two small improvements that came out of investigating a support email, where a user's source recording was moved/deleted (most likely by OBS auto-remux) after they had opened it and marked ~60 segments. Export then failed with a bare ffmpeg error, and they spent a long time working through the generic troubleshooting checklist, none of which could have helped.

## 1. Only pass muxer private options to the muxer they belong to

`-movflags` (mov/mp4 family) and `-default_mode` (matroska family) were added to every ffmpeg command regardless of the output format, so exporting to matroska produced:

```
... -movflags "+faststart" -default_mode infer_no_subs -f matroska ...
```

ffmpeg tolerates private options belonging to a different muxer, so this was harmless — but it adds noise to the command line we log, show under **Last commands** and include in problem reports, which makes troubleshooting harder than it needs to be.

Each set of flags is now gated on the output format.

The format lists are derived from ffmpeg's `movenc.c` and `matroskaenc.c` rather than reusing the existing `util/streams.ts` `isMov`/`isMatroska` helpers. Those are narrower, UI-oriented lists that omit movenc formats LosslessCut can output (`3gp`, `3g2`, `f4v`, `psp`) — reusing them would have silently dropped `+faststart` for those. `isMov`/`isMatroska` are left untouched, since `isMov` also drives subtitle codec selection in `getMapStreamsArgs` and widening it would be a separate behavioural change.

When the output format is unknown (`concatFiles` takes it as optional), ffmpeg infers the muxer from the file extension, so the flags are kept as before.

## 2. Detect a missing source file in the remaining export paths

Follow-up to #2797. `cutMultiple` already calls `assertFileExists` before spawning ffmpeg, so a source file that was moved or deleted after being opened gives a clear *"Source file no longer exists or is not accessible…"* message instead of a raw `ExecaError` plus the generic **Unable to export this file** checklist.

The other export paths had no such guard and still failed with a bare ffmpeg `No such file or directory`. The same check is now applied to:

- `captureFramesRange` — export segment frames as images
- `captureFrameFromFfmpeg` — capture snapshot
- `extractStreams` — extract all tracks / extract single track

`extractAllStreams` and `extractSingleStream` swallowed the message and showed a generic toast, so `UserFacingError` is now let through there too, matching how the export and merge flows already handle it.

## Testing

`yarn tsc`, `yarn lint` and `yarn test` all pass (85 tests).

No unit test was added for the flag gating: the helpers live in `useFfmpegOperations.ts`, which calls `window.require('node:path')` at module scope and so can't be imported under vitest without new test scaffolding. Happy to move the two pure helpers (and the format sets) into a testable module under `util/` if you'd prefer that covered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqUn6Bh7hWqPqWejqR8p7u)_