### PR TITLE
Build AppImage with the static (libfuse2-free) runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,9 @@
     "zod": "^4.4.3"
   },
   "build": {
+    "toolsets": {
+      "appimage": "1.0.3"
+    },
     "directories": {
       "buildResources": "build-resources"
     },


### PR DESCRIPTION
Fixes #3022

## Problem

We don't set `build.toolsets`, so electron-builder falls back to its default AppImage toolset (`"0.0.0"` → `buildLegacyFuse2AppImage`, using the AppImageKit `appimage-12.0.1` runtime). That runtime `dlopen`s `libfuse.so.2` at startup — the exact failure in the issue. Strings from the runtime electron-builder currently downloads:

```
dlopen
libfuse.so.2
dlopen(): error loading libfuse.so.2
```

So the AppImage won't start on distros that no longer ship libfuse2 unless the user installs it manually.

## Change

One config addition in `package.json`:

```json
"toolsets": {
  "appimage": "1.0.3"
},
```

This switches the AppImage target to `buildStaticRuntimeAppImage`. Verified the toolset it pulls (checksum matches the one pinned in app-builder-lib):

```
AppImage/type2-runtime release: 20251108
runtimes/runtime-x64: ELF 64-bit LSB pie executable, static-pie linked, stripped
ldd: not a dynamic executable       # libfuse + squashfuse linked in
```

No libfuse2, no fuse3 — nothing to install.

This is only needed while we're on electron-builder v26, whose default is still the FUSE2 runtime (checked in 26.15.7). v27 defaults to a static bundle, so the key can just be deleted then — tracked in #3025.

## Notes / things to be aware of

- electron-builder's typings label `1.0.2`/`1.0.3` as **betas**; `0.0.0` is still its default. `1.0.3` is the newer of the two, and the one that survived into the v27 alphas (`1.0.2` was dropped from the enum there).
- Squashfs compression changes: the static-runtime path defaults to **zstd** and does not support xz (xz is mapped to zstd). The bundled runtime handles zstd fine; only relevant if something external unsquashes the image.
- `--no-sandbox` handling changes: the legacy toolset bakes it into the desktop `Exec=` line, while the static toolset's generated `AppRun` probes `unshare -Ur true` and only appends `--no-sandbox` when user namespaces are unavailable.
- The toolset version is a closed enum validated by electron-builder's config schema at build time, so a future electron-builder that drops `1.0.3` fails the build loudly rather than silently reverting to the fuse2 runtime.
- Verified at the toolset/runtime level, not by launching a built image — worth one `yarn pack-linux` before release to confirm end to end.
