### PR TITLE
Revert snap base to electron-builder's default

### DIFF
--- a/package.json
+++ b/package.json
@@ -480,7 +480,6 @@
       ]
     },
     "snap": {
-      "base": "core22",
       "plugs": [
         "default",
         "removable-media"


### PR DESCRIPTION
Fixes #3002. Reverts the one-line change from #2809.

## The problem

The published snap declares `base: core22` but still plugs the core18-era `gnome-3-28-1804` content snap as its GNOME platform. That platform's Mesa drivers can't resolve their dependencies against core22, so every GL/EGL path fails — including the `swrast` software fallback — the GPU process exits, and the main process segfaults before a window appears. It's not GPU-specific, because even software rendering is unavailable.

## Why `base` alone didn't do what #2809 expected

That PR assumed core22 would pull in the 22.04 GNOME platform. It doesn't. electron-builder's snap template hardcodes both halves:

```yaml
# app-builder-lib/templates/snap/snapcraft.yaml
base: core20
...
plugs:
  gnome-3-28-1804:
    interface: content
    target: $SNAP/gnome-platform
    default-provider: gnome-3-28-1804
```

and the legacy snap path rewrites only the `base` field, never touching `plugs`:

```js
// app-builder-lib/out/targets/snap/coreLegacy.js
if (options.base != null) {
  snap.base = options.base
  ...
}
```

So the config produced a core22 snap with a core18 platform. The crash log confirms which one is live at runtime: the `MESA-LOADER` search path in #3002 is exactly `$SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/dri`, which is what the template's launcher scripts set `LIBGL_DRIVERS_PATH` to.

Worth noting these two halves are frozen together — the template is byte-identical in the newest electron-builder (26.15.7), so this isn't fixable by upgrading. Pointing the platform at `gnome-42-2204` or moving to the newer `snapcraft`/core24 config are both possible, but each means owning a non-default snap setup, which isn't worth it here.

## The change

Drop the `base` override so the template stays self-consistent, exactly as electron-builder ships it. Dropping the key rather than pinning `core20` explicitly means the snap keeps following the template if electron-builder moves it forward.

## Trade-off

This restores the pre-3.68 snap, which reopens #2614 for very new GPUs whose hardware needs a newer Mesa than the platform provides. That's a deliberate trade: #2614 affected some GPUs, the current state affects every snap user.

## Testing

Not built — this is a revert to the configuration that shipped for years before #2809, and the resulting snap is byte-for-byte the pre-#2809 one. The config validates against electron-builder's own `scheme.json`. The reporter in #3002 offered to verify a build on the affected hardware.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KboMatXCuTgjD6KfC1ik12)_