### PR TITLE
Remove mention of 'crop' feature from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ The main feature is lossless trimming and cutting of video and audio files, whic
 - Black scene detection, silent audio detection, and scene change detection
 - Divide timeline into segments of length L, size (X MB), N number of segments or even randomized segments!
 - Speed up / slow down video or audio file ([changing FPS](https://github.com/mifi/lossless-cut/issues/1712))
-- Lossless crop and aspect ratio modification
 - Basic [CLI](docs/cli.md) and [HTTP API](docs/api.md)
 - Show (DJI) embedded GPS track on a map
 - Losslessly Download videos over HTTP (e.g. HLS `.m3u8`)


### PR DESCRIPTION
The readme advertises a 'crop' feature despite the app not actually having this ability (yet). See #643 and #372 (issues that mention the Apps current lack of this feature), and the FAQ: https://github.com/mifi/lossless-cut/blob/9820b32856f007a710c9e33ea9cc91886330770f/docs/index.md?plain=1#L28-L29

This PR removes that incorrect claim.