### PR TITLE
Restore shortcuts after editing segment time

### DIFF
--- a/src/renderer/src/BottomBar.tsx
+++ b/src/renderer/src/BottomBar.tsx
@@ -23,6 +23,7 @@ import getSwal from './swal';
 import { getSegColor as getSegColorRaw } from './util/colors';
 import { useSegColors } from './contexts';
 import { isExactDurationMatch } from './util/duration';
+import handleCutTimeInputKeyDown from './util/inputFocus';
 import useUserSettings from './hooks/useUserSettings';
 import useActionTitle from './hooks/useActionTitle';
 import { askForPlaybackRate, checkAppPath } from './dialogs';
@@ -251,6 +252,7 @@ const CutTimeInput = memo(({ disabled, darkMode, cutTime, setCutTime, startTimeO
         onChange={(e) => handleCutTimeInput(e.target.value)}
         onPaste={handleCutTimePaste}
         onBlur={handleInputBlur}
+        onKeyDown={(e) => handleCutTimeInputKeyDown(e, isStart)}
         onContextMenu={handleContextMenu}
         value={renderValue()}
       />

--- a/src/renderer/src/util/inputFocus.test.ts
+++ b/src/renderer/src/util/inputFocus.test.ts
@@ -1,0 +1,37 @@
+import { expect, it, vi } from 'vitest';
+
+import handleCutTimeInputKeyDown from './inputFocus';
+
+
+function createKeyEvent({ code, shiftKey = false }: { code: string, shiftKey?: boolean }) {
+  return {
+    code,
+    shiftKey,
+    preventDefault: vi.fn(),
+    currentTarget: { blur: vi.fn() },
+  };
+}
+
+it('should release focus when tabbing forward from the end time input', () => {
+  const event = createKeyEvent({ code: 'Tab' });
+
+  handleCutTimeInputKeyDown(event, false);
+
+  expect(event.preventDefault).toHaveBeenCalledOnce();
+  expect(event.currentTarget.blur).toHaveBeenCalledOnce();
+});
+
+it.each([
+  { name: 'the start time input', code: 'Tab', shiftKey: false, isStart: true },
+  { name: 'backwards tabbing', code: 'Tab', shiftKey: true, isStart: false },
+  { name: 'enter', code: 'Enter', shiftKey: false, isStart: false },
+  { name: 'escape', code: 'Escape', shiftKey: false, isStart: false },
+  { name: 'text editing', code: 'Digit1', shiftKey: false, isStart: false },
+])('should preserve focus for $name', ({ code, shiftKey, isStart }) => {
+  const event = createKeyEvent({ code, shiftKey });
+
+  handleCutTimeInputKeyDown(event, isStart);
+
+  expect(event.preventDefault).not.toHaveBeenCalled();
+  expect(event.currentTarget.blur).not.toHaveBeenCalled();
+});

--- a/src/renderer/src/util/inputFocus.ts
+++ b/src/renderer/src/util/inputFocus.ts
@@ -1,0 +1,13 @@
+import type { KeyboardEvent } from 'react';
+
+
+type CutTimeInputKeyEvent = Pick<KeyboardEvent<HTMLInputElement>, 'code' | 'shiftKey' | 'preventDefault'> & {
+  currentTarget: Pick<HTMLInputElement, 'blur'>,
+};
+
+export default function handleCutTimeInputKeyDown(e: CutTimeInputKeyEvent, isStart: boolean | undefined) {
+  if (isStart || e.code !== 'Tab' || e.shiftKey) return;
+
+  e.preventDefault();
+  e.currentTarget.blur();
+}


### PR DESCRIPTION
## Problem

Segment time inputs correctly suppress application shortcuts while editing. After tabbing forward out of the end-time input, however, focus moved to the Zoom select. The global shortcut handler only accepts events targeted at `document.body`, so segment shortcuts stayed disabled until clicking the player returned focus to the document.

## Solution

Treat forward Tab from the final/end time input as leaving the cut-time editor: prevent native focus from moving to the Zoom select and blur that input. This reuses the existing blur lifecycle and restores document focus without changing global shortcut matching or allowing application shortcuts inside text fields.

## Behavior

- Start-time Tab still moves to the end-time input; Shift+Tab still moves backwards.
- While a time or other text input is focused, normal text editing and its shortcuts remain protected.
- After forward Tab leaves the end-time input, all configured application shortcuts are available again.
- No player click/play-pause cycle is required.

## Tests

- `yarn test run src/renderer/src/util/inputFocus.test.ts`
- `yarn test run`
- `yarn tsc`
- `yarn lint`
- `yarn build`
- `yarn check`
- `git diff --check`

## Manual verification

On macOS 15.7.7 ARM64 with the Electron dev build and a generated H.264/AAC MP4:

- reproduced on unmodified master: end-time Tab focused Zoom and shortcuts remained disabled until a player click;
- verified the current default `Shift+=`, `Ctrl+'`, and custom `Ctrl+n` bindings;
- verified editing protection, start/end Tab navigation, Shift+Tab, Enter, Escape, mouse-away focus, repeated edit/create cycles, ordinary text-editing shortcuts, and Space playback control.

## Limitations

- Not manually tested on Linux (the reporter's platform) or Windows.
- Physical left/right Ctrl were not separately synthesized on macOS; the existing shortcut matcher treats either side through `ctrlKey`.

Fixes #2942
