### PR TITLE
fix: inflated output duration when copying attached_pic streams

### DIFF
--- a/src/renderer/src/hooks/useFfmpegOperations.ts
+++ b/src/renderer/src/hooks/useFfmpegOperations.ts
@@ -6,7 +6,7 @@ import i18n from 'i18next';
 
 import { getSuffixedOutPath, transferTimestamps, getOutFileExtension, getOutDir, getHtml5ifiedPath, unlinkWithRetry, getFrameDuration, isMac, html5ifiedPrefix, html5dummySuffix, assertFileExists } from '../util';
 import { isCuttingStart, isCuttingEnd, runFfmpegWithProgress, getFfCommandLine, getDuration, createChaptersFromSegments, readFileFfprobeMeta, getExperimentalArgs, getVideoTimescaleArgs, logStdoutStderr, runFfmpegConcat, RefuseOverwriteError, runFfmpeg } from '../ffmpeg';
-import { getMapStreamsArgs, getStreamIdsToCopy, getStreamById, isStreamThumbnail } from '../util/streams';
+import { getEffectiveAvoidNegativeTs, getMapStreamsArgs, getStreamById, getStreamIdsToCopy, isStreamThumbnail } from '../util/streams';
 import { needsSmartCut, getCodecParams } from '../smartcut';
 import { getGuaranteedSegments, isDurationValid } from '../segments';
 import type { FFprobeStream } from '../../../common/ffprobe';
@@ -297,15 +297,11 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
     const copyFileStreamsFiltered = copyFileStreams.filter(({ streamIds }) => streamIds.length > 0);
 
     // remove -avoid_negative_ts make_zero when not cutting start (no -ss), or else some videos get blank first frame in QuickLook
-    // A copied attached_pic (cover art) packet has no timeline position, so with -ss before -i,
-    // make_zero/make_non_negative derive the file-wide timestamp correction from it, which
-    // results in an empty edit and an inflated reported output duration (#3009).
-    // `auto` doesn't use the cover art as the correction reference, so downgrade to it.
     const copiedAttachedPicStream = copyFileStreams.some(({ streamIds, path }) => streamIds.some((streamId) => {
       const stream = getStreamById({ allFilesMeta, streamId, path });
       return stream != null && isStreamThumbnail(stream);
     }));
-    const effectiveAvoidNegativeTs = copiedAttachedPicStream && (avoidNegativeTs === 'make_zero' || avoidNegativeTs === 'make_non_negative') ? 'auto' : avoidNegativeTs;
+    const effectiveAvoidNegativeTs = getEffectiveAvoidNegativeTs({ avoidNegativeTs, hasCopiedAttachedPicStream: copiedAttachedPicStream });
     const avoidNegativeTsArgs = cuttingStart && effectiveAvoidNegativeTs && ssBeforeInput ? ['-avoid_negative_ts', String(effectiveAvoidNegativeTs)] : [];
 
     // If cutting multiple files, `-ss` must be before `-i`, regardless of `ssBeforeInput` choice

--- a/src/renderer/src/hooks/useFfmpegOperations.ts
+++ b/src/renderer/src/hooks/useFfmpegOperations.ts
@@ -6,7 +6,7 @@ import i18n from 'i18next';
 
 import { getSuffixedOutPath, transferTimestamps, getOutFileExtension, getOutDir, getHtml5ifiedPath, unlinkWithRetry, getFrameDuration, isMac, html5ifiedPrefix, html5dummySuffix, assertFileExists } from '../util';
 import { isCuttingStart, isCuttingEnd, runFfmpegWithProgress, getFfCommandLine, getDuration, createChaptersFromSegments, readFileFfprobeMeta, getExperimentalArgs, getVideoTimescaleArgs, logStdoutStderr, runFfmpegConcat, RefuseOverwriteError, runFfmpeg } from '../ffmpeg';
-import { getMapStreamsArgs, getStreamIdsToCopy } from '../util/streams';
+import { getMapStreamsArgs, getStreamIdsToCopy, getStreamById, isStreamThumbnail } from '../util/streams';
 import { needsSmartCut, getCodecParams } from '../smartcut';
 import { getGuaranteedSegments, isDurationValid } from '../segments';
 import type { FFprobeStream } from '../../../common/ffprobe';
@@ -297,7 +297,16 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
     const copyFileStreamsFiltered = copyFileStreams.filter(({ streamIds }) => streamIds.length > 0);
 
     // remove -avoid_negative_ts make_zero when not cutting start (no -ss), or else some videos get blank first frame in QuickLook
-    const avoidNegativeTsArgs = cuttingStart && avoidNegativeTs && ssBeforeInput ? ['-avoid_negative_ts', String(avoidNegativeTs)] : [];
+    // A copied attached_pic (cover art) packet has no timeline position, so with -ss before -i,
+    // make_zero/make_non_negative derive the file-wide timestamp correction from it, which
+    // results in an empty edit and an inflated reported output duration (#3009).
+    // `auto` doesn't use the cover art as the correction reference, so downgrade to it.
+    const copiedAttachedPicStream = copyFileStreams.some(({ streamIds, path }) => streamIds.some((streamId) => {
+      const stream = getStreamById({ allFilesMeta, streamId, path });
+      return stream != null && isStreamThumbnail(stream);
+    }));
+    const effectiveAvoidNegativeTs = copiedAttachedPicStream && (avoidNegativeTs === 'make_zero' || avoidNegativeTs === 'make_non_negative') ? 'auto' : avoidNegativeTs;
+    const avoidNegativeTsArgs = cuttingStart && effectiveAvoidNegativeTs && ssBeforeInput ? ['-avoid_negative_ts', String(effectiveAvoidNegativeTs)] : [];
 
     // If cutting multiple files, `-ss` must be before `-i`, regardless of `ssBeforeInput` choice
     // and it seems that `-t` must be after `-i` #896

--- a/src/renderer/src/util/streams.test.ts
+++ b/src/renderer/src/util/streams.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 
-import { getMapStreamsArgs, getStreamIdsToCopy } from './streams';
+import { getEffectiveAvoidNegativeTs, getMapStreamsArgs, getStreamIdsToCopy } from './streams';
 import type { FFprobeStreamDisposition } from '../../../common/ffprobe';
 import type { LiteFFprobeStream } from '../types';
 
@@ -163,4 +163,15 @@ test('ass output', () => {
   })).toEqual([
     '-map', '0:0', '-c:0', 'ass',
   ]);
+});
+
+test('getEffectiveAvoidNegativeTs downgrades to auto when copying an attached_pic stream (#3009)', () => {
+  expect(getEffectiveAvoidNegativeTs({ avoidNegativeTs: 'make_zero', hasCopiedAttachedPicStream: true })).toBe('auto');
+  expect(getEffectiveAvoidNegativeTs({ avoidNegativeTs: 'make_non_negative', hasCopiedAttachedPicStream: true })).toBe('auto');
+
+  // no cover art copied: user preference passes through
+  expect(getEffectiveAvoidNegativeTs({ avoidNegativeTs: 'make_zero', hasCopiedAttachedPicStream: false })).toBe('make_zero');
+  expect(getEffectiveAvoidNegativeTs({ avoidNegativeTs: 'auto', hasCopiedAttachedPicStream: true })).toBe('auto');
+  expect(getEffectiveAvoidNegativeTs({ avoidNegativeTs: 'disabled', hasCopiedAttachedPicStream: true })).toBe('disabled');
+  expect(getEffectiveAvoidNegativeTs({ avoidNegativeTs: undefined, hasCopiedAttachedPicStream: true })).toBeUndefined();
 });

--- a/src/renderer/src/util/streams.ts
+++ b/src/renderer/src/util/streams.ts
@@ -1,4 +1,5 @@
 import invariant from 'tiny-invariant';
+import type { AvoidNegativeTs } from '../../../common/types';
 import type { FFprobeStream, FFprobeStreamDisposition } from '../../../common/ffprobe';
 import type { AllFilesMeta, ChromiumHTMLAudioElement, ChromiumHTMLVideoElement, CopyfileStreams, LiteFFprobeStream } from '../types';
 import type { FileStream } from '../ffmpeg';
@@ -261,6 +262,18 @@ export const attachedPicDisposition = 'attached_pic';
 export function isStreamThumbnail(stream: Pick<FFprobeStream, 'codec_type' | 'disposition'>) {
   return stream && stream.codec_type === 'video' && stream.disposition?.[attachedPicDisposition] === 1;
 }
+
+/**
+ * A copied attached_pic (cover art) packet has no timeline position, so with keyframe
+ * cutting (`-ss` before `-i`) ffmpeg applies the seek offset to it anyway and it reaches
+ * the muxer first. `-avoid_negative_ts make_zero`/`make_non_negative` then derives its
+ * file-wide timestamp correction from that packet, which records an empty edit and
+ * inflates the reported output duration (#3009). `auto` doesn't use the cover art as the
+ * correction reference, so it's used instead when a copied stream is a thumbnail.
+ */
+export const getEffectiveAvoidNegativeTs = ({ avoidNegativeTs, hasCopiedAttachedPicStream }: { avoidNegativeTs: AvoidNegativeTs | undefined, hasCopiedAttachedPicStream: boolean }) => (
+  hasCopiedAttachedPicStream && (avoidNegativeTs === 'make_zero' || avoidNegativeTs === 'make_non_negative') ? 'auto' : avoidNegativeTs
+);
 
 export const getAudioStreams = <T extends Pick<FFprobeStream, 'codec_type'>>(streams: T[]) => streams.filter((stream) => stream.codec_type === 'audio');
 export const getRealVideoStreams = <T extends Pick<FFprobeStream, 'codec_type' | 'disposition'>>(streams: T[]) => streams.filter((stream) => stream.codec_type === 'video' && !isStreamThumbnail(stream));


### PR DESCRIPTION
Fixes #3009

## Problem

Exports of files containing a cover art (`attached_pic`) stream reported inflated durations (e.g. a 100s segment reporting 300s). The audio itself was intact — only the declared duration in `mvhd` was wrong.

Root cause (analysis by @reporter in #3009): an `attached_pic` packet has no timeline position and is emitted at pts 0. With `-ss` before `-i`, ffmpeg applies the seek offset to it anyway, so it reaches the muxer first, and `make_zero`/`make_non_negative` derive the file-wide timestamp correction from it — recording an empty edit that inflates the duration.

## Change

In `losslessCutSingle`, when any stream selected for copying is an attached_pic thumbnail and the user's `avoid_negative_ts` is `make_zero` or `make_non_negative`, downgrade it to `auto` for that export. `auto` doesn't use the cover art as the correction reference.

- Keeps the cover art in the output (unlike deselecting the track)
- Non-keyframe cuts and exports without cover art are unaffected
- User-set `auto`/`disabled` pass through unchanged

## Verification

Reproduced locally with the synthetic file from the issue (700s AAC + blue-frame cover art, cut at 200s for 100s):

| args | mvhd duration | cover art kept |
|---|---|---|
| `make_zero` (old behavior) | **300.01s** ❌ | yes |
| `auto` (new behavior) | **100.01s** ✅ | yes |

`yarn tsc` and eslint clean on the changed file.

Credit for the excellent root-cause analysis goes entirely to the issue reporter.
