### PR TITLE
Fix playback and conversion of audio with a non-standard channel layout

### DIFF
--- a/src/common/ffprobe.ts
+++ b/src/common/ffprobe.ts
@@ -50,7 +50,7 @@
  * @property {string} [sample_fmt] The audio sample format (not present if codec_type is not "audio")
  * @property {string} [sample_rate] A string representation of an integer showing the audio sample rate (not present if codec_type is not "audio")
  * @property {number} [channels] The audio track's channel count (not present if codec_type is not "audio")
- * @property {'stereo'|'mono'} [channel_layout] The audio track's channel layout (e.g. "stereo") (not present if codec_type is not "audio")
+ * @property {string} [channel_layout] The audio track's channel layout (e.g. "stereo") (not present if codec_type is not "audio")
  * @property {number} [bits_per_sample] Bits per audio sample (might not be accurate, may just be 0) (not present if codec_type is not "audio")
  * @property {number} [width] The video stream width (also available for images) (not present if codec_type is not "video")
  * @property {number} [height] The stream height (also available for images) (not present if codec_type is not "video")
@@ -346,7 +346,7 @@ export interface FFprobeStream {
   /**
    * The audio track's channel layout (e.g. "stereo") (not present if codec_type is not "audio")
    */
-  channel_layout?: 'stereo' | 'mono',
+  channel_layout?: string,
 
   /**
    * Bits per audio sample (might not be accurate, may just be 0) (not present if codec_type is not "audio")

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -9,6 +9,19 @@ export interface KeyBinding {
 
 export type FfmpegHwAccel = 'none' | 'auto' | 'vdpau' | 'dxva2' | 'd3d11va' | 'vaapi' | 'qsv' | 'videotoolbox';
 
+/**
+ * The parts of an audio stream's ffprobe data needed to decide whether its channel layout
+ * has to be fixed up before ffmpeg can resample or downmix it. See `getFixChannelLayoutFilter`.
+ */
+export interface AudioChannelInfo {
+  channels?: number | undefined,
+  channelLayout?: string | undefined,
+}
+
+export interface AudioStreamInfo extends AudioChannelInfo {
+  index: number,
+}
+
 export type CaptureFormat = 'jpeg' | 'png' | 'webp';
 
 export type TimecodeFormat = 'timecodeWithDecimalFraction' | 'frameCount' | 'seconds' | 'timecodeWithFramesFraction';

--- a/src/common/util.test.ts
+++ b/src/common/util.test.ts
@@ -1,23 +1,28 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, test } from 'vitest';
 
-import { getFixChannelLayoutFilter, hasUnsupportedChannelLayout } from './util.js';
+import { getFixChannelLayoutFilter, hasCustomChannelLayout } from './util.js';
 
-describe('hasUnsupportedChannelLayout', () => {
-  test('detects unused/unknown channels', () => {
+describe('hasCustomChannelLayout', () => {
+  test('detects layouts that ffmpeg could not express natively', () => {
     // e.g. DV/DVCPRO .mov captured by Final Cut / iMovie
-    expect(hasUnsupportedChannelLayout('4 channels (UNSD+UNSD+UNSD+UNSD)')).toBe(true);
-    expect(hasUnsupportedChannelLayout('3 channels (FL+FR+UNK)')).toBe(true);
+    expect(hasCustomChannelLayout('4 channels (UNSD+UNSD+UNSD+UNSD)')).toBe(true);
+    expect(hasCustomChannelLayout('3 channels (FL+FR+UNK)')).toBe(true);
+    // known positions, but not a standard speaker set (e.g. a surround stem pair)
+    expect(hasCustomChannelLayout('2 channels (BL+BR)')).toBe(true);
+    expect(hasCustomChannelLayout('2 channels (SL+SR)')).toBe(true);
+    expect(hasCustomChannelLayout('4 channels (FL+FR+FC+BL)')).toBe(true);
   });
 
   test('accepts layouts that swresample supports', () => {
-    expect(hasUnsupportedChannelLayout('stereo')).toBe(false);
-    expect(hasUnsupportedChannelLayout('mono')).toBe(false);
-    expect(hasUnsupportedChannelLayout('5.1(side)')).toBe(false);
-    expect(hasUnsupportedChannelLayout('2.1')).toBe(false);
+    expect(hasCustomChannelLayout('stereo')).toBe(false);
+    expect(hasCustomChannelLayout('mono')).toBe(false);
+    expect(hasCustomChannelLayout('5.1(side)')).toBe(false);
+    expect(hasCustomChannelLayout('2.1')).toBe(false);
+    expect(hasCustomChannelLayout('quad')).toBe(false);
     // unspecified layouts are fine, ffmpeg just uses a default downmix
-    expect(hasUnsupportedChannelLayout('4 channels')).toBe(false);
-    expect(hasUnsupportedChannelLayout(undefined)).toBe(false);
+    expect(hasCustomChannelLayout('4 channels')).toBe(false);
+    expect(hasCustomChannelLayout(undefined)).toBe(false);
   });
 });
 
@@ -25,6 +30,7 @@ describe('getFixChannelLayoutFilter', () => {
   test('relabels all channels of an unsupported layout', () => {
     expect(getFixChannelLayoutFilter({ channels: 4, channelLayout: '4 channels (UNSD+UNSD+UNSD+UNSD)' })).toBe('channelmap=0|1|2|3');
     expect(getFixChannelLayoutFilter({ channels: 3, channelLayout: '3 channels (FL+FR+UNK)' })).toBe('channelmap=0|1|2');
+    expect(getFixChannelLayoutFilter({ channels: 2, channelLayout: '2 channels (BL+BR)' })).toBe('channelmap=0|1');
     expect(getFixChannelLayoutFilter({ channels: 1, channelLayout: '1 channels (UNSD)' })).toBe('channelmap=0');
   });
 

--- a/src/common/util.test.ts
+++ b/src/common/util.test.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { describe, expect, test } from 'vitest';
+
+import { getFixChannelLayoutFilter, hasUnsupportedChannelLayout } from './util.js';
+
+describe('hasUnsupportedChannelLayout', () => {
+  test('detects unused/unknown channels', () => {
+    // e.g. DV/DVCPRO .mov captured by Final Cut / iMovie
+    expect(hasUnsupportedChannelLayout('4 channels (UNSD+UNSD+UNSD+UNSD)')).toBe(true);
+    expect(hasUnsupportedChannelLayout('3 channels (FL+FR+UNK)')).toBe(true);
+  });
+
+  test('accepts layouts that swresample supports', () => {
+    expect(hasUnsupportedChannelLayout('stereo')).toBe(false);
+    expect(hasUnsupportedChannelLayout('mono')).toBe(false);
+    expect(hasUnsupportedChannelLayout('5.1(side)')).toBe(false);
+    expect(hasUnsupportedChannelLayout('2.1')).toBe(false);
+    // unspecified layouts are fine, ffmpeg just uses a default downmix
+    expect(hasUnsupportedChannelLayout('4 channels')).toBe(false);
+    expect(hasUnsupportedChannelLayout(undefined)).toBe(false);
+  });
+});
+
+describe('getFixChannelLayoutFilter', () => {
+  test('relabels all channels of an unsupported layout', () => {
+    expect(getFixChannelLayoutFilter({ channels: 4, channelLayout: '4 channels (UNSD+UNSD+UNSD+UNSD)' })).toBe('channelmap=0|1|2|3');
+    expect(getFixChannelLayoutFilter({ channels: 3, channelLayout: '3 channels (FL+FR+UNK)' })).toBe('channelmap=0|1|2');
+    expect(getFixChannelLayoutFilter({ channels: 1, channelLayout: '1 channels (UNSD)' })).toBe('channelmap=0');
+  });
+
+  test('leaves supported layouts alone', () => {
+    expect(getFixChannelLayoutFilter({ channels: 2, channelLayout: 'stereo' })).toBeUndefined();
+    expect(getFixChannelLayoutFilter({ channels: 6, channelLayout: '5.1' })).toBeUndefined();
+  });
+
+  test('needs a channel count to build the map', () => {
+    expect(getFixChannelLayoutFilter({ channels: undefined, channelLayout: '4 channels (UNSD+UNSD+UNSD+UNSD)' })).toBeUndefined();
+    expect(getFixChannelLayoutFilter({ channels: 0, channelLayout: '4 channels (UNSD+UNSD+UNSD+UNSD)' })).toBeUndefined();
+  });
+});

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -1,4 +1,4 @@
-import type { FfmpegHwAccel } from './types.ts';
+import type { AudioChannelInfo, FfmpegHwAccel } from './types.ts';
 
 export const parseFfprobeDuration = (durationStr: string | undefined) => (
   durationStr != null ? parseFloat(durationStr) : undefined
@@ -41,10 +41,7 @@ export const hasCustomChannelLayout = (channelLayout: string | undefined) => (
 // The `channelmap` filter re-labels the channels without touching the samples, which turns the layout
 // into a plain "N channels" (unspecified) layout. swresample handles those by skipping the rematrixing
 // step entirely, so the stream then behaves exactly as if it had carried no channel layout information.
-export function getFixChannelLayoutFilter({ channels, channelLayout }: {
-  channels?: number | undefined,
-  channelLayout?: string | undefined,
-}) {
+export function getFixChannelLayoutFilter({ channels, channelLayout }: AudioChannelInfo) {
   if (channels == null || channels <= 0 || !hasCustomChannelLayout(channelLayout)) return undefined;
   return `channelmap=${Array.from({ length: channels }, (_, i) => i).join('|')}`;
 }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -19,3 +19,24 @@ export function parseRatio(str: string, char = '/') {
   if (den <= 0) return undefined;
   return num / den;
 }
+
+// ffmpeg's swresample cannot handle channel layouts that contain unknown ("UNK") or unused ("UNSD")
+// channels, which ffprobe describes like "4 channels (UNSD+UNSD+UNSD+UNSD)". Such layouts occur in
+// e.g. DV/DVCPRO .mov files, whose 'chan' atom labels every channel as "unused". Any operation that
+// needs to resample or downmix such a stream then fails with:
+//   [SWR] Input channel layout '4 channels (UNSD+UNSD+UNSD+UNSD)' is not supported
+// (swresample only accepts native or fully-specified custom layouts, see swr_init in libswresample)
+export const hasUnsupportedChannelLayout = (channelLayout: string | undefined) => (
+  channelLayout != null && /\b(?:UNK|UNSD)\b/.test(channelLayout)
+);
+
+// The `channelmap` filter re-labels the channels without touching the samples, which turns the
+// layout into a plain "N channels" (unspecified) layout that swresample does support. The stream
+// then behaves exactly as if it had carried no channel layout information at all.
+export function getFixChannelLayoutFilter({ channels, channelLayout }: {
+  channels?: number | undefined,
+  channelLayout?: string | undefined,
+}) {
+  if (channels == null || channels <= 0 || !hasUnsupportedChannelLayout(channelLayout)) return undefined;
+  return `channelmap=${Array.from({ length: channels }, (_, i) => i).join('|')}`;
+}

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -20,23 +20,31 @@ export function parseRatio(str: string, char = '/') {
   return num / den;
 }
 
-// ffmpeg's swresample cannot handle channel layouts that contain unknown ("UNK") or unused ("UNSD")
-// channels, which ffprobe describes like "4 channels (UNSD+UNSD+UNSD+UNSD)". Such layouts occur in
-// e.g. DV/DVCPRO .mov files, whose 'chan' atom labels every channel as "unused". Any operation that
-// needs to resample or downmix such a stream then fails with:
+// ffmpeg's swresample only accepts channel layouts that it considers "sane" (see sane_layout() in
+// libswresample/rematrix.c): a native layout, or a custom one whose channels form a standard speaker
+// set. Anything else is rejected outright when the resampler initializes, so any operation that
+// resamples or downmixes such a stream fails with:
 //   [SWR] Input channel layout '4 channels (UNSD+UNSD+UNSD+UNSD)' is not supported
-// (swresample only accepts native or fully-specified custom layouts, see swr_init in libswresample)
-export const hasUnsupportedChannelLayout = (channelLayout: string | undefined) => (
-  channelLayout != null && /\b(?:UNK|UNSD)\b/.test(channelLayout)
+// There is no flag to relax this check.
+//
+// ffprobe describes a layout it could not express natively as "N channels (A+B+...)", e.g.
+// "4 channels (UNSD+UNSD+UNSD+UNSD)" for DV/DVCPRO .mov files, whose 'chan' atom labels every channel
+// as unused, or "2 channels (BL+BR)" for a surround stem pair. Layouts that do form a standard set are
+// reported under their native name instead ("stereo", "5.1"), and those always work.
+// A plain "N channels" (no positions at all) is also fine, which is what the fix below produces.
+const customChannelLayoutRegex = /^\d+ channels \(/;
+
+export const hasCustomChannelLayout = (channelLayout: string | undefined) => (
+  channelLayout != null && customChannelLayoutRegex.test(channelLayout)
 );
 
-// The `channelmap` filter re-labels the channels without touching the samples, which turns the
-// layout into a plain "N channels" (unspecified) layout that swresample does support. The stream
-// then behaves exactly as if it had carried no channel layout information at all.
+// The `channelmap` filter re-labels the channels without touching the samples, which turns the layout
+// into a plain "N channels" (unspecified) layout. swresample handles those by skipping the rematrixing
+// step entirely, so the stream then behaves exactly as if it had carried no channel layout information.
 export function getFixChannelLayoutFilter({ channels, channelLayout }: {
   channels?: number | undefined,
   channelLayout?: string | undefined,
 }) {
-  if (channels == null || channels <= 0 || !hasUnsupportedChannelLayout(channelLayout)) return undefined;
+  if (channels == null || channels <= 0 || !hasCustomChannelLayout(channelLayout)) return undefined;
   return `channelmap=${Array.from({ length: channels }, (_, i) => i).join('|')}`;
 }

--- a/src/main/compatPlayer.ts
+++ b/src/main/compatPlayer.ts
@@ -11,14 +11,14 @@ export function createMediaSourceStream(params: Parameters<typeof createMediaSou
   const abort = () => abortController.abort();
 
   async function attemptCreateProcess({ forceColorspace }: { forceColorspace?: boolean } = {}) {
-    const { videoStreamIndex, audioStreamIndexes, seekTo } = params;
+    const { videoStreamIndex, audioStreams, seekTo } = params;
 
-    logger.info('Starting preview process', { videoStreamIndex, audioStreamIndexes, seekTo });
+    logger.info('Starting preview process', { videoStreamIndex, audioStreams, seekTo });
     const process = createMediaSourceProcess({ ...params, forceColorspace });
 
     // eslint-disable-next-line unicorn/prefer-add-event-listener
     abortController.signal.onabort = () => {
-      logger.info('Aborting preview process', { videoStreamIndex, audioStreamIndexes, seekTo });
+      logger.info('Aborting preview process', { videoStreamIndex, audioStreams, seekTo });
       process.kill('SIGKILL');
     };
 

--- a/src/main/ffmpeg.ts
+++ b/src/main/ffmpeg.ts
@@ -15,7 +15,7 @@ import type { FFprobeFormat } from '../common/ffprobe.js';
 import isDev from './isDev.js';
 import logger from './logger.js';
 import { parseFfmpegProgressLine } from './progress.js';
-import { formatFfmpegNumber, getHwaccelArgs, parseFfprobeDuration } from '../common/util.js';
+import { formatFfmpegNumber, getFixChannelLayoutFilter, getHwaccelArgs, parseFfprobeDuration } from '../common/util.js';
 import { getFfmpegJpegQuality } from './ffmpegUtil.js';
 import { throwIfDisabledNetworking } from './networking.js';
 
@@ -591,10 +591,10 @@ export async function getDuration(filePath: string) {
 const enableLog = false;
 const encode = true;
 
-export function createMediaSourceProcess({ path, videoStreamIndex, audioStreamIndexes, seekTo, size, fps, rotate, forceColorspace, ffmpegHwaccel }: {
+export function createMediaSourceProcess({ path, videoStreamIndex, audioStreams, seekTo, size, fps, rotate, forceColorspace, ffmpegHwaccel }: {
   path: string,
   videoStreamIndex?: number | undefined,
-  audioStreamIndexes: number[],
+  audioStreams: { index: number, channels?: number | undefined, channelLayout?: string | undefined }[],
   seekTo: number,
   size?: number | undefined,
   fps?: number | undefined,
@@ -664,18 +664,24 @@ export function createMediaSourceProcess({ path, videoStreamIndex, audioStreamIn
       graph.push(`[0:${videoStreamIndex}]${videoFiltersStr}[video]`);
     }
 
-    if (audioStreamIndexes.length > 0) {
-      if (audioStreamIndexes.length > 1) {
-        const resampledStr = audioStreamIndexes.map((i) => `[resampled${i}]`).join('');
-        const weightsStr = audioStreamIndexes.map(() => '1').join(' ');
+    if (audioStreams.length > 0) {
+      // some streams have a channel layout that ffmpeg cannot resample or downmix, so relabel it first
+      const getAudioFilters = (stream: typeof audioStreams[number], rest: string[]) => {
+        const filters = [getFixChannelLayoutFilter(stream), ...rest].filter((filter) => filter != null);
+        return filters.length > 0 ? filters.join(',') : 'anull';
+      };
+
+      if (audioStreams.length > 1) {
+        const resampledStr = audioStreams.map(({ index }) => `[resampled${index}]`).join('');
+        const weightsStr = audioStreams.map(() => '1').join(' ');
         graph.push(
           // First resample because else we get the lowest sample rate
-          ...audioStreamIndexes.map((i) => `[0:${i}]aresample=44100[resampled${i}]`),
+          ...audioStreams.map((stream) => `[0:${stream.index}]${getAudioFilters(stream, ['aresample=44100'])}[resampled${stream.index}]`),
           // now mix all audio channels together
-          `${resampledStr}amix=inputs=${audioStreamIndexes.length}:duration=longest:weights=${weightsStr}:normalize=0:dropout_transition=2[audio]`,
+          `${resampledStr}amix=inputs=${audioStreams.length}:duration=longest:weights=${weightsStr}:normalize=0:dropout_transition=2[audio]`,
         );
       } else {
-        graph.push(`[0:${audioStreamIndexes[0]}]anull[audio]`);
+        graph.push(`[0:${audioStreams[0]!.index}]${getAudioFilters(audioStreams[0]!, [])}[audio]`);
       }
     }
 
@@ -727,7 +733,7 @@ export function createMediaSourceProcess({ path, videoStreamIndex, audioStreamIn
         '-g', '1', // reduces latency and buffering
       ] : ['-vn']),
 
-      ...(audioStreamIndexes.length > 0 ? [
+      ...(audioStreams.length > 0 ? [
         '-map', '[audio]',
         '-ac', '2', '-c:a', 'aac', '-b:a', '128k',
       ] : ['-an']),

--- a/src/main/ffmpeg.ts
+++ b/src/main/ffmpeg.ts
@@ -10,7 +10,7 @@ import type { Readable } from 'node:stream';
 import { app, clipboard, nativeImage } from 'electron';
 
 import { platform, arch, isWindows, isLinux } from './util.js';
-import type { CaptureFormat, FfmpegHwAccel } from '../common/types.js';
+import type { AudioStreamInfo, CaptureFormat, FfmpegHwAccel } from '../common/types.js';
 import type { FFprobeFormat } from '../common/ffprobe.js';
 import isDev from './isDev.js';
 import logger from './logger.js';
@@ -594,7 +594,7 @@ const encode = true;
 export function createMediaSourceProcess({ path, videoStreamIndex, audioStreams, seekTo, size, fps, rotate, forceColorspace, ffmpegHwaccel }: {
   path: string,
   videoStreamIndex?: number | undefined,
-  audioStreams: { index: number, channels?: number | undefined, channelLayout?: string | undefined }[],
+  audioStreams: AudioStreamInfo[],
   seekTo: number,
   size?: number | undefined,
   fps?: number | undefined,
@@ -666,7 +666,7 @@ export function createMediaSourceProcess({ path, videoStreamIndex, audioStreams,
 
     if (audioStreams.length > 0) {
       // some streams have a channel layout that ffmpeg cannot resample or downmix, so relabel it first
-      const getAudioFilters = (stream: typeof audioStreams[number], rest: string[]) => {
+      const getAudioFilters = (stream: AudioStreamInfo, rest: string[]) => {
         const filters = [getFixChannelLayoutFilter(stream), ...rest].filter((filter) => filter != null);
         return filters.length > 0 ? filters.join(',') : 'anull';
       };

--- a/src/renderer/src/MediaSourcePlayer.tsx
+++ b/src/renderer/src/MediaSourcePlayer.tsx
@@ -8,7 +8,7 @@ import isDev from './isDev';
 import type { ChromiumHTMLVideoElement } from './types';
 import type { FFprobeStream } from '../../common/ffprobe';
 import { getFrameDuration } from './util';
-import type { FfmpegHwAccel } from '../../common/types';
+import type { AudioStreamInfo, FfmpegHwAccel } from '../../common/types';
 
 const { compatPlayer: { createMediaSourceStream } } = window.require('@electron/remote').require('./index.js');
 
@@ -18,7 +18,7 @@ async function startPlayback({ path, slaveVideo, masterVideo, videoStreamIndex, 
   slaveVideo: ChromiumHTMLVideoElement,
   masterVideo: ChromiumHTMLVideoElement,
   videoStreamIndex?: number | undefined,
-  audioStreams: { index: number, channels?: number | undefined, channelLayout?: string | undefined }[],
+  audioStreams: AudioStreamInfo[],
   seekTo: number,
   signal: AbortSignal,
   size?: number | undefined,

--- a/src/renderer/src/MediaSourcePlayer.tsx
+++ b/src/renderer/src/MediaSourcePlayer.tsx
@@ -13,12 +13,12 @@ import type { FfmpegHwAccel } from '../../common/types';
 const { compatPlayer: { createMediaSourceStream } } = window.require('@electron/remote').require('./index.js');
 
 
-async function startPlayback({ path, slaveVideo, masterVideo, videoStreamIndex, audioStreamIndexes, seekTo, signal, size, fps, rotate, onCanPlay, onResetNeeded, onWaiting, ffmpegHwaccel }: {
+async function startPlayback({ path, slaveVideo, masterVideo, videoStreamIndex, audioStreams, seekTo, signal, size, fps, rotate, onCanPlay, onResetNeeded, onWaiting, ffmpegHwaccel }: {
   path: string,
   slaveVideo: ChromiumHTMLVideoElement,
   masterVideo: ChromiumHTMLVideoElement,
   videoStreamIndex?: number | undefined,
-  audioStreamIndexes: number[],
+  audioStreams: { index: number, channels?: number | undefined, channelLayout?: string | undefined }[],
   seekTo: number,
   signal: AbortSignal,
   size?: number | undefined,
@@ -73,7 +73,7 @@ async function startPlayback({ path, slaveVideo, masterVideo, videoStreamIndex, 
 
   const codecs: string[] = [];
   if (videoStreamIndex != null) codecs.push('avc1.42C01F');
-  if (audioStreamIndexes.length > 0) codecs.push('mp4a.40.2');
+  if (audioStreams.length > 0) codecs.push('mp4a.40.2');
   const codecTag = codecs.join(', ');
 
   const mimeCodec = `video/mp4; codecs="${codecTag}"`;
@@ -90,7 +90,7 @@ async function startPlayback({ path, slaveVideo, masterVideo, videoStreamIndex, 
     throw new Error(`Unsupported MIME type or codec: ${mimeCodec}`);
   }
 
-  mediaSourceProcess = createMediaSourceStream({ path, videoStreamIndex, audioStreamIndexes, seekTo, size, fps, rotate, ffmpegHwaccel });
+  mediaSourceProcess = createMediaSourceStream({ path, videoStreamIndex, audioStreams, seekTo, size, fps, rotate, ffmpegHwaccel });
   console.log('Waiting for media source process to emit first data...');
   const readChunk = await mediaSourceProcess.promise;
   if (readChunk == null) {
@@ -325,7 +325,7 @@ function MediaSourcePlayer({ rotate, filePath, videoStream, audioStreams, master
     console.error('video error', error);
   }, []);
 
-  const audioStreamIndexes = useMemo(() => audioStreams.map((s) => s.index), [audioStreams]);
+  const audioStreamsForPreview = useMemo(() => audioStreams.map(({ index, channels, channel_layout: channelLayout }) => ({ index, channels, channelLayout })), [audioStreams]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -369,7 +369,7 @@ function MediaSourcePlayer({ rotate, filePath, videoStream, audioStreams, master
           slaveVideo: video,
           masterVideo,
           videoStreamIndex: videoStream?.index,
-          audioStreamIndexes,
+          audioStreams: audioStreamsForPreview,
           seekTo,
           size,
           fps,
@@ -398,7 +398,7 @@ function MediaSourcePlayer({ rotate, filePath, videoStream, audioStreams, master
 
     return () => abortController.abort();
     // Important that we also have eventId in the deps, so that we can restart the preview when the eventId changes
-  }, [audioStreamIndexes, ffmpegHwaccel, filePath, masterVideoRef, mediaSourceQuality, rotate, videoStream]);
+  }, [audioStreamsForPreview, ffmpegHwaccel, filePath, masterVideoRef, mediaSourceQuality, rotate, videoStream]);
 
   const onFocus = useCallback<FocusEventHandler<HTMLVideoElement>>((e) => {
     // prevent video element from stealing focus in fullscreen mode https://github.com/mifi/lossless-cut/issues/543#issuecomment-1868167775

--- a/src/renderer/src/hooks/useFfmpegOperations.ts
+++ b/src/renderer/src/hooks/useFfmpegOperations.ts
@@ -15,7 +15,7 @@ import { deleteDispositionValue, type AllFilesMeta, type Chapter, type CopyfileS
 import type { LossyMode } from '../../../main';
 import { UserFacingError } from '../../errors';
 import mainApi from '../mainApi';
-import { formatFfmpegNumber, getHwaccelArgs } from '../../../common/util';
+import { formatFfmpegNumber, getFixChannelLayoutFilter, getHwaccelArgs, hasUnsupportedChannelLayout } from '../../../common/util';
 
 const { join, resolve, dirname } = window.require('node:path');
 const { writeFile, mkdir, access, constants: { W_OK } } = window.require('node:fs/promises');
@@ -887,6 +887,26 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
       }
     }
 
+    // Some files (e.g. DV/DVCPRO .mov) have an audio channel layout that ffmpeg cannot resample or
+    // downmix, which makes the encode fail. Relabel the channels first so that it can.
+    // We don't pass -map, so ffmpeg picks one audio stream by itself. Therefore only apply the filter
+    // when every audio stream has the same channel count, or the filter might not match the picked stream.
+    let audioFilterArgs: string[] = [];
+    if (audio != null && audio !== 'copy') {
+      try {
+        const audioStreams = (await readFileFfprobeMeta(filePathArg)).streams.filter((s) => s.codec_type === 'audio');
+        const unsupportedStream = audioStreams.find((s) => hasUnsupportedChannelLayout(s.channel_layout));
+        const sameChannelCount = new Set(audioStreams.map((s) => s.channels)).size === 1;
+        if (unsupportedStream != null && sameChannelCount) {
+          const filter = getFixChannelLayoutFilter({ channels: unsupportedStream.channels, channelLayout: unsupportedStream.channel_layout });
+          if (filter != null) audioFilterArgs = ['-af', filter];
+        }
+      } catch (err) {
+        // don't fail the conversion just because we couldn't probe it
+        console.warn('Failed to probe audio channel layout', err);
+      }
+    }
+
     const ffmpegArgs = [
       '-hide_banner',
       ...((video === 'lq' || video === 'hq') ? getHwaccelArgs(ffmpegHwaccel) : []),
@@ -894,6 +914,7 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
       '-i', filePathArg,
       ...videoArgs,
       ...audioArgs,
+      ...audioFilterArgs,
       '-sn',
       '-y', outPath,
     ];

--- a/src/renderer/src/hooks/useFfmpegOperations.ts
+++ b/src/renderer/src/hooks/useFfmpegOperations.ts
@@ -15,7 +15,7 @@ import { deleteDispositionValue, type AllFilesMeta, type Chapter, type CopyfileS
 import type { LossyMode } from '../../../main';
 import { UserFacingError } from '../../errors';
 import mainApi from '../mainApi';
-import { formatFfmpegNumber, getFixChannelLayoutFilter, getHwaccelArgs, hasUnsupportedChannelLayout } from '../../../common/util';
+import { formatFfmpegNumber, getFixChannelLayoutFilter, getHwaccelArgs, hasCustomChannelLayout } from '../../../common/util';
 
 const { join, resolve, dirname } = window.require('node:path');
 const { writeFile, mkdir, access, constants: { W_OK } } = window.require('node:fs/promises');
@@ -895,7 +895,7 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
     if (audio != null && audio !== 'copy') {
       try {
         const audioStreams = (await readFileFfprobeMeta(filePathArg)).streams.filter((s) => s.codec_type === 'audio');
-        const unsupportedStream = audioStreams.find((s) => hasUnsupportedChannelLayout(s.channel_layout));
+        const unsupportedStream = audioStreams.find((s) => hasCustomChannelLayout(s.channel_layout));
         const sameChannelCount = new Set(audioStreams.map((s) => s.channels)).size === 1;
         if (unsupportedStream != null && sameChannelCount) {
           const filter = getFixChannelLayoutFilter({ channels: unsupportedStream.channels, channelLayout: unsupportedStream.channel_layout });

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -16,4 +16,9 @@
   "include": [
     "src/common/**/*",
   ],
+  // tests are run by vitest from the sources; don't emit them into the build output,
+  // or vitest would discover and run the compiled copies too
+  "exclude": [
+    "src/common/**/*.test.ts",
+  ],
 }

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -16,9 +16,4 @@
   "include": [
     "src/common/**/*",
   ],
-  // tests are run by vitest from the sources; don't emit them into the build output,
-  // or vitest would discover and run the compiled copies too
-  "exclude": [
-    "src/common/**/*.test.ts",
-  ],
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,7 @@
   },
   "include": [
     "electron.vite.config.ts",
+    "vitest.config.ts",
     "i18next.config*.ts",
     "script/**/*",
   ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // `tsc --build` compiles src/common (tests included) into common-ts-dist. Don't discover those
+    // compiled copies, or every test in src/common would also run a second time from the build output.
+    exclude: [...configDefaults.exclude, 'common-ts-dist/**'],
+  },
+});


### PR DESCRIPTION
## Problem

Reported for a DV/DVCPRO `.mov` (Canon ZR600 captured via Final Cut / iMovie). Both preview playback and "Convert to supported format" fail:

```
[auto_aresample_0 @ ...] [SWR @ ...] Input channel layout '4 channels (UNSD+UNSD+UNSD+UNSD)' is not supported
[auto_aresample_0 @ ...] Failed to configure output pad on auto_aresample_0
[af#0:1 @ ...] Error reinitializing filters!
[out#0/mp4 @ ...] Nothing was written into output file, because at least one of its streams received no packets.
Conversion failed!
```

The `aac_at`/`libx264` errors further down that log are collateral — the encoders never opened because the audio filter died first.

## Cause

Not the DV codec and not the encoder — the **audio channel layout**. The file's `chan` atom labels every channel as *unused*, so ffmpeg reports `4 channels (UNSD+UNSD+UNSD+UNSD)`.

`sane_layout()` in `libswresample/rematrix.c` rejects this unconditionally when the resampler initializes:

```c
if(!sane_layout(&in_ch_layout)) {
    av_log(..., "Input channel layout '%s' is not supported\n", buf);
    ret = AVERROR(EINVAL);   // no flag, no strictness level, no override
    goto fail;
}
```

So *any* operation that resamples or downmixes the stream fails. `-ac 2` is not a workaround — it is the trigger, and it is already in both failing commands.

## Fix

Prepend a `channelmap` filter, which re-labels the channels into a plain "N channels" unspecified layout. swresample handles that by skipping rematrixing entirely, so the stream behaves exactly as if it had carried no channel layout information.

It only relabels — sample data is untouched — and it's applied only to streams that need it, so files with a proper layout keep their correct downmix.

Applied in:
- `src/main/ffmpeg.ts` — the preview filter graph, both the single-stream and the multi-stream `amix` branches (the latter was broken too)
- `src/renderer/src/hooks/useFfmpegOperations.ts` — html5ify, for all non-`copy` audio modes

## Scope: wider than just DV

`sane_layout()` also requires at least one front speaker and symmetric pairs, so custom layouts with perfectly well-labelled channels fail the same way. Detection therefore keys off ffprobe reporting a layout as `"N channels (A+B+...)"`, which is exactly when ffmpeg could not express it as a native layout. Layouts that do form a standard set are reported under their native name (`stereo`, `quad`, `5.1`) and always work.

Verified through a `.mov` roundtrip of every layout:

| layout | before | after |
|---|---|---|
| `4 channels (UNSD+UNSD+UNSD+UNSD)` — the reported DV case | FAIL | OK |
| `2 channels (BL+BR)` — surround stem pair | FAIL | OK |
| `2 channels (SL+SR)` | FAIL | OK |
| `2 channels (TFL+TFR)` — height pair | FAIL | OK |
| `3 channels (FL+FR+SL)` | FAIL | OK |
| `4 channels (FL+FR+FC+BL)` — partial 5.1 | FAIL | OK |
| `stereo`, `mono`, `2.1`, `3.0`, `quad`, `5.1` … | OK | untouched |

All 76 layouts `ffmpeg -layouts` knows were tested: 75 pass unaided, and the one that doesn't (`binaural`) never survives into a container. Matroska never fails either — it drops to unspecified.

## Verification

No sample file was available, so I built a byte-faithful one: a DV + PCM `.mov` with a hex-patched `chan` atom containing four `kAudioChannelLabel_Unused` descriptions. ffprobe reports the identical stream line to the reported file, and LosslessCut's real commands reproduce the identical error and exit code 234.

Every previously-failing command now succeeds and produces real audio+video. I also confirmed the fix is a pure relabel two ways: raw samples are byte-identical before/after, and the result is byte-identical to the same file carrying no `chan` atom at all.

Alternatives ruled out empirically, all still failing 234: `-ac`/`-ar` in any combination, `-ac 2` as an input option, `-request_channel_layout`, `-guess_layout_max 0`, `aformat=channel_layouts=...`, and `aresample=in_chlayout=`/`used_chlayout=`. `pan` "worked" but silently produced near-silent output (-91 dB) on the broken layout, so it is not usable.

## Notes

- html5ify now runs one extra ffprobe to get channel counts, because it passes no `-map` and `convertFormatBatch` operates on unprobed files. It's non-fatal, and the filter is only applied when all audio streams share a channel count, so the ambiguous multi-audio case is left unchanged rather than newly broken.
- `FFprobeStream.channel_layout` was typed `'stereo' | 'mono'`; widened to `string`.
- Added `vitest.config.ts` excluding `common-ts-dist`. `src/common/util.test.ts` is the first test under `src/common`, and that's the only project emitting runnable JS (`tsconfig.main.json` is `emitDeclarationOnly`), so without it `tsc --build` output would be discovered and every such test would run twice.
- Two harmless over-applications: `1 channels (FL)` and `2 channels (FC+LFE)` are custom-but-sane, so they get flattened despite already working. The cost is a plain rather than positional downmix; I preferred that to missing the stem-pair cases.

## Possibly an upstream ffmpeg bug

`libavformat/mov_chan.c` already asks for normalization after reading the atom:

```c
ret = av_channel_layout_retype(ch_layout, 0, AV_CHANNEL_LAYOUT_RETYPE_FLAG_CANONICAL);
```

which routes to `canonical_order()` in `libavutil/channel_layout.c`:

```c
if (channel_layout->u.map[i].id != AV_CHAN_UNKNOWN)
    has_known_channel = 1;
if (!has_known_channel)
    return AV_CHANNEL_ORDER_UNSPEC;   // collapse "no positions at all"
```

That is exactly the graceful fallback needed — but `mov_get_channel_id(0)` returns `AV_CHAN_UNUSED` (0x200), while the test compares against `AV_CHAN_UNKNOWN` (0x300). Confirmed by hex-patching the repro to use a label that maps to `AV_CHAN_UNKNOWN` and changing nothing else: it is then auto-normalized and works unaided. Worth reporting upstream, though it would fix only the all-unused case, and not in any ffmpeg build LosslessCut ships today.

## Checks

`yarn tsc`, `yarn lint` and all 90 tests pass. Unit tests added for the detection and filter construction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCf7BBiPqNLUjVoN7rTCF6)_