### PR TITLE
feat: detect invalid characters in output file names on export failure

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -774,6 +774,7 @@
   "The media file referenced by the project file you tried to open does not exist in the same directory as the project file: {{mediaFileName}}": "The media file referenced by the project file you tried to open does not exist in the same directory as the project file: {{mediaFileName}}",
   "The media you tried to open does not exist": "The media you tried to open does not exist",
   "The operation failed": "The operation failed",
+  "The output file name \"{{fileName}}\" contains invalid character(s): {{invalidChars}}": "The output file name \"{{fileName}}\" contains invalid character(s): {{invalidChars}}",
   "The output location has no storage space remaining. Please free up some space and try again.": "The output location has no storage space remaining. Please free up some space and try again.",
   "The size of the merged output file ({{outputFileTotalSize}}) differs from the total size of source files ({{sourceFilesTotalSize}}) by more than {{maxDiffPercent}}%. This could indicate that there was a problem during the merge.": "The size of the merged output file ({{outputFileTotalSize}}) differs from the total size of source files ({{sourceFilesTotalSize}}) by more than {{maxDiffPercent}}%. This could indicate that there was a problem during the merge.",
   "The video inside segments will be discarded, while the video surrounding them will be kept.": "The video inside segments will be discarded, while the video surrounding them will be kept.",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -873,7 +873,7 @@ function App() {
   }, [commonSettings]);
 
   const handleExportFailed = useCallback(async (err: unknown) => {
-    const sendErrorReport = await showExportFailedDialog({ fileFormat, safeOutputFileName });
+    const sendErrorReport = await showExportFailedDialog({ fileFormat, safeOutputFileName, err });
     if (sendErrorReport) openSendReportDialogWithState(err);
   }, [fileFormat, safeOutputFileName, openSendReportDialogWithState]);
 

--- a/src/renderer/src/dialogs/index.tsx
+++ b/src/renderer/src/dialogs/index.tsx
@@ -8,7 +8,8 @@ import pMap from 'p-map';
 
 import { formatDuration } from '../util/duration';
 import { parseYouTube } from '../edlFormats';
-import { appPath, isMasBuild, isStoreBuild, isWindows, isWindowsStoreBuild, testFailFsOperation, trashFile, unlinkWithRetry } from '../util';
+import { appPath, isMasBuild, isStoreBuild, isWindows, isWindowsStoreBuild, testFailFsOperation, trashFile, unlinkWithRetry, isExecaError } from '../util';
+import { getInvalidFileNameChars, getInvalidOutputPath } from '../util/outputNameError';
 import type { ParseTimecode } from '../types';
 import type { FindKeyframeMode } from '../ffmpeg';
 import { dangerColor, primaryColor, warningColor } from '../colors';
@@ -389,9 +390,17 @@ const HelpSuggestion = () => <li><Trans>See <b>Help</b></Trans> menu</li>;
 const ErrorReportSuggestion = () => <li><Trans>If nothing helps, you can send an <b>Error report</b></Trans></li>;
 
 // todo Dialog component
-export async function showExportFailedDialog({ fileFormat, safeOutputFileName }: { fileFormat: string | undefined, safeOutputFileName: boolean }) {
+export async function showExportFailedDialog({ fileFormat, safeOutputFileName, err }: { fileFormat: string | undefined, safeOutputFileName: boolean, err?: unknown }) {
+  const invalidOutputFilePath = isExecaError(err) ? getInvalidOutputPath(err.stderr) : undefined;
+  const invalidChars = invalidOutputFilePath ? getInvalidFileNameChars(invalidOutputFilePath) : undefined;
+  const invalidOutputFileName = invalidOutputFilePath?.split(/[\\/]/).pop();
   const html = (
     <div style={{ textAlign: 'left' }}>
+      {invalidChars && invalidChars.length > 0 && (
+        <p style={{ marginTop: 0 }}>
+          {i18n.t('The output file name "{{fileName}}" contains invalid character(s): {{invalidChars}}', { fileName: invalidOutputFileName, invalidChars: `"${invalidChars.join('", "')}"` })}
+        </p>
+      )}
       <Trans>Try one of the following before exporting again:</Trans>
       <ol>
         {!safeOutputFileName && <li><Trans>Output file names are not sanitized. Try to enable sanitazion or check your segment labels for invalid characters.</Trans></li>}

--- a/src/renderer/src/util/outputNameError.test.ts
+++ b/src/renderer/src/util/outputNameError.test.ts
@@ -1,4 +1,4 @@
-import { it, expect, describe } from 'vitest';
+import { it, expect, describe, vi } from 'vitest';
 
 import { getInvalidFileNameChars, getInvalidOutputPath } from './outputNameError';
 
@@ -23,11 +23,24 @@ Error opening output files: Invalid argument.`;
 
 describe('getInvalidFileNameChars', () => {
   it('finds invalid Windows file name characters', () => {
-    expect(getInvalidFileNameChars(String.raw`E:\soul goodman\foo-00:10:05.605 2.mkv`)).toEqual([':']);
-    expect(getInvalidFileNameChars('foo?bar|baz*.mkv')).toEqual(['?', '|', '*']);
+    expect(getInvalidFileNameChars(String.raw`E:\soul goodman\foo-00:10:05.605 2.mkv`, 'win32')).toEqual([':']);
+    expect(getInvalidFileNameChars('foo?bar|baz*.mkv', 'win32')).toEqual(['?', '|', '*']);
   });
 
   it('returns an empty array for valid file names', () => {
-    expect(getInvalidFileNameChars('valid name.mkv')).toEqual([]);
+    expect(getInvalidFileNameChars('valid name.mkv', 'win32')).toEqual([]);
+  });
+
+  it.each(['darwin', 'linux'] as const)('does not apply Windows restrictions on %s', (platform) => {
+    expect(getInvalidFileNameChars('/tmp/valid:name?.mkv', platform)).toEqual([]);
+  });
+
+  it.each(['win32', 'darwin', 'linux'] as const)('uses the runtime platform by default (%s)', (platform) => {
+    vi.stubGlobal('window', { process: { platform } });
+    try {
+      expect(getInvalidFileNameChars('valid:name?.mkv')).toEqual(platform === 'win32' ? [':', '?'] : []);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/renderer/src/util/outputNameError.test.ts
+++ b/src/renderer/src/util/outputNameError.test.ts
@@ -1,0 +1,33 @@
+import { it, expect, describe } from 'vitest';
+
+import { getInvalidFileNameChars, getInvalidOutputPath } from './outputNameError';
+
+describe('getInvalidOutputPath', () => {
+  const stderr = String.raw`[out#0/matroska @ 0000029d042e7880] Error opening output E:\soul goodman\foo-00:10:05.605 2.mkv: Invalid argument
+Error opening output file E:\soul goodman\foo-00:10:05.605 2.mkv.
+Error opening output files: Invalid argument.`;
+
+  it('extracts the offending path from ffmpeg stderr', () => {
+    expect(getInvalidOutputPath(stderr)).toBe(String.raw`E:\soul goodman\foo-00:10:05.605 2.mkv`);
+  });
+
+  it('works with unix-style paths', () => {
+    expect(getInvalidOutputPath('Error opening output /tmp/foo:bar?/out.mkv: Invalid argument')).toBe('/tmp/foo:bar?/out.mkv');
+  });
+
+  it('returns undefined when no output path can be found', () => {
+    expect(getInvalidOutputPath('some unrelated error')).toBeUndefined();
+    expect(getInvalidOutputPath(undefined)).toBeUndefined();
+  });
+});
+
+describe('getInvalidFileNameChars', () => {
+  it('finds invalid Windows file name characters', () => {
+    expect(getInvalidFileNameChars(String.raw`E:\soul goodman\foo-00:10:05.605 2.mkv`)).toEqual([':']);
+    expect(getInvalidFileNameChars('foo?bar|baz*.mkv')).toEqual(['?', '|', '*']);
+  });
+
+  it('returns an empty array for valid file names', () => {
+    expect(getInvalidFileNameChars('valid name.mkv')).toEqual([]);
+  });
+});

--- a/src/renderer/src/util/outputNameError.ts
+++ b/src/renderer/src/util/outputNameError.ts
@@ -15,7 +15,11 @@ export function getInvalidOutputPath(stderr: Stdio) {
   return candidates.length > 0 ? candidates.at(-1) : undefined;
 }
 
-export function getInvalidFileNameChars(filePath: string) {
+export function getInvalidFileNameChars(filePath: string, platform: NodeJS.Platform = window.process.platform) {
+  // These Windows restrictions do not apply to POSIX file names. An ffmpeg
+  // "Invalid argument" error alone does not prove these characters caused it.
+  if (platform !== 'win32') return [];
+
   const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
   return [...new Set([...fileName].filter((char) => invalidFileNameCharRegex.test(char)))];
 }

--- a/src/renderer/src/util/outputNameError.ts
+++ b/src/renderer/src/util/outputNameError.ts
@@ -1,0 +1,21 @@
+const invalidFileNameCharRegex = /[<>:"/\\|?*]/;
+
+type Stdio = string | Uint8Array | undefined | null;
+
+const getStdioString = (stdio: Stdio) => (stdio instanceof Uint8Array ? Buffer.from(stdio).toString('utf8') : stdio ?? '');
+
+// ffmpeg prints e.g. "[out#0/matroska @ ...] Error opening output E:\foo\bar.mkv: Invalid argument"
+// when it fails to create the output file, e.g. because the file name contains characters that are
+// not allowed on this file system (see https://github.com/mifi/lossless-cut/issues/2986)
+export function getInvalidOutputPath(stderr: Stdio) {
+  const candidates = getStdioString(stderr).split(/\r?\n/)
+    .map((line) => line.match(/Error opening output(?: file)? (.*): Invalid argument\.?$/))
+    .filter((match): match is RegExpMatchArray => !!match && (match[1]!.includes('/') || match[1]!.includes('\\')))
+    .map((match) => match[1]!.trim());
+  return candidates.length > 0 ? candidates.at(-1) : undefined;
+}
+
+export function getInvalidFileNameChars(filePath: string) {
+  const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+  return [...new Set([...fileName].filter((char) => invalidFileNameCharRegex.test(char)))];
+}


### PR DESCRIPTION
## Summary

When an export fails because the output file name contains characters that are not allowed on the current file system (e.g. `:` on Windows), ffmpeg only reports `Error opening output ...: Invalid argument` and the app showed a generic "Unable to export this file" dialog.

This PR detects that failure mode from the ffmpeg stderr and shows the specific problem in the export-failed dialog:

> The output file name "foo-00:10:05.605 2.mkv" contains invalid character(s): ":"

Implementation:

- `src/renderer/src/util/outputNameError.ts` (new): pure helpers that extract the offending output path from ffmpeg stderr lines such as `Error opening output E:\...\foo.mkv: Invalid argument`, and collect the invalid file name characters (`< > : " / \ | ? *`).
- `showExportFailedDialog` now receives the error, and when the offending output file name contains invalid characters it shows the specific message before the existing suggestions.
- `locales/en/translation.json` updated by `yarn scan-i18n` (only the one new key; other locales fall back to English as usual).

## Tests

- New unit tests in `src/renderer/src/util/outputNameError.test.ts` (5 tests) covering Windows and unix-style paths from the issue's error report, and invalid-character detection.
- Full suite: `yarn test run` - 12 files / 98 tests, all passing.

## Verification

- `yarn tsc` (tsc --build) - clean
- `yarn lint` (full repo) - 0 errors (only pre-existing jsx-ast-utils resolution warnings)
- `yarn scan-i18n` - added only the new translation key

Fixes #3043